### PR TITLE
feat: Extract `tags` in `getTypeDocumentation`

### DIFF
--- a/.changeset/brave-chairs-kiss.md
+++ b/.changeset/brave-chairs-kiss.md
@@ -1,0 +1,5 @@
+---
+"@tsxmod/utils": minor
+---
+
+feat: Extract `tags` in `getTypeDocumentation`

--- a/packages/utils/src/symbols/getSymbolTags.ts
+++ b/packages/utils/src/symbols/getSymbolTags.ts
@@ -1,0 +1,9 @@
+import { ts, Symbol } from 'ts-morph'
+
+/** Gets the tags from a symbol's JSDoc. */
+export function getSymbolTags(symbol: Symbol) {
+  return symbol.getJsDocTags().map((tag) => ({
+    name: tag.getName(),
+    text: ts.displayPartsToString(tag.getText()),
+  }))
+}

--- a/packages/utils/src/symbols/index.ts
+++ b/packages/utils/src/symbols/index.ts
@@ -1,1 +1,2 @@
 export { getSymbolDescription } from './getSymbolDescription'
+export { getSymbolTags } from './getSymbolTags'

--- a/packages/utils/src/types/getTypeDocumentation.test.ts
+++ b/packages/utils/src/types/getTypeDocumentation.test.ts
@@ -26,6 +26,7 @@ describe('getTypeDocumentation', () => {
       required: false,
       properties: null,
       description,
+      tags: [],
     })
   })
 
@@ -48,6 +49,7 @@ describe('getTypeDocumentation', () => {
       defaultValue: undefined,
       required: true,
       description: null,
+      tags: [],
       properties: [
         {
           name: 'initialCount',
@@ -56,6 +58,7 @@ describe('getTypeDocumentation', () => {
           required: false,
           properties: null,
           description,
+          tags: [],
         },
       ],
     })
@@ -79,6 +82,7 @@ describe('getTypeDocumentation', () => {
       defaultValue: '{}',
       required: false,
       description: null,
+      tags: [],
       properties: [
         {
           name: 'initial',
@@ -93,9 +97,11 @@ describe('getTypeDocumentation', () => {
               required: true,
               properties: null,
               description: null,
+              tags: [],
             },
           ],
           description: null,
+          tags: [],
         },
       ],
     })
@@ -120,6 +126,7 @@ describe('getTypeDocumentation', () => {
       required: false,
       properties: null,
       description: null,
+      tags: [],
     })
   })
 
@@ -142,6 +149,7 @@ describe('getTypeDocumentation', () => {
       required: false,
       properties: null,
       description: null,
+      tags: [],
     })
   })
 
@@ -168,6 +176,7 @@ describe('getTypeDocumentation', () => {
       required: true,
       properties: null,
       description: null,
+      tags: [],
     })
   })
 
@@ -195,6 +204,7 @@ describe('getTypeDocumentation', () => {
       required: true,
       properties: null,
       description: null,
+      tags: [],
     })
   })
 
@@ -228,9 +238,11 @@ describe('getTypeDocumentation', () => {
           required: true,
           properties: null,
           description: null,
+          tags: [],
         },
       ],
       description: null,
+      tags: [],
     })
   })
 
@@ -259,6 +271,7 @@ describe('getTypeDocumentation', () => {
           properties: null,
           required: true,
           description: null,
+          tags: [],
         },
       ],
       unionProperties: [
@@ -266,6 +279,7 @@ describe('getTypeDocumentation', () => {
           {
             defaultValue: undefined,
             description: null,
+            tags: [],
             name: 'source',
             properties: null,
             required: true,
@@ -276,6 +290,7 @@ describe('getTypeDocumentation', () => {
           {
             defaultValue: undefined,
             description: null,
+            tags: [],
             name: 'value',
             properties: null,
             required: true,
@@ -284,6 +299,7 @@ describe('getTypeDocumentation', () => {
         ],
       ],
       description: null,
+      tags: [],
     })
   })
 
@@ -310,6 +326,7 @@ describe('getTypeDocumentation', () => {
           {
             defaultValue: undefined,
             description: null,
+            tags: [],
             name: null,
             properties: null,
             required: true,
@@ -324,10 +341,12 @@ describe('getTypeDocumentation', () => {
             properties: null,
             required: true,
             description: null,
+            tags: [],
           },
         ],
       ],
       description: null,
+      tags: [],
     })
   })
 
@@ -361,6 +380,7 @@ describe('getTypeDocumentation', () => {
           required: true,
           properties: null,
           description: null,
+          tags: [],
         },
       ],
       unionProperties: [
@@ -368,6 +388,7 @@ describe('getTypeDocumentation', () => {
           {
             defaultValue: undefined,
             description: null,
+            tags: [],
             name: 'source',
             properties: null,
             required: true,
@@ -378,6 +399,7 @@ describe('getTypeDocumentation', () => {
           {
             defaultValue: undefined,
             description: null,
+            tags: [],
             name: 'value',
             properties: null,
             required: true,
@@ -386,6 +408,7 @@ describe('getTypeDocumentation', () => {
         ],
       ],
       description: null,
+      tags: [],
     })
   })
 
@@ -441,6 +464,7 @@ describe('getTypeDocumentation', () => {
           "name": "className",
           "properties": null,
           "required": false,
+          "tags": [],
           "text": "string",
         },
         {
@@ -449,6 +473,7 @@ describe('getTypeDocumentation', () => {
           "name": "children",
           "properties": null,
           "required": true,
+          "tags": [],
           "text": "ReactNode",
         },
         {
@@ -457,6 +482,7 @@ describe('getTypeDocumentation', () => {
           "name": "variant",
           "properties": null,
           "required": false,
+          "tags": [],
           "text": ""heading1" | "heading2" | "heading3" | "body1"",
         },
         {
@@ -465,6 +491,7 @@ describe('getTypeDocumentation', () => {
           "name": "alignment",
           "properties": null,
           "required": true,
+          "tags": [],
           "text": ""start" | "center" | "end"",
         },
         {
@@ -473,6 +500,7 @@ describe('getTypeDocumentation', () => {
           "name": "width",
           "properties": null,
           "required": true,
+          "tags": [],
           "text": "string | number",
         },
         {
@@ -481,6 +509,7 @@ describe('getTypeDocumentation', () => {
           "name": "lineHeight",
           "properties": null,
           "required": true,
+          "tags": [],
           "text": "string",
         },
       ]
@@ -528,6 +557,7 @@ describe('getTypeDocumentation', () => {
               "name": "gridTemplateColumns",
               "properties": null,
               "required": true,
+              "tags": [],
               "text": "string",
             },
             {
@@ -536,10 +566,12 @@ describe('getTypeDocumentation', () => {
               "name": "gridTemplateRows",
               "properties": null,
               "required": false,
+              "tags": [],
               "text": "string",
             },
           ],
           "required": true,
+          "tags": [],
           "text": "PolymorphicComponentProps<"web", Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, GridProps>, AsTarget, ForwardedAsTarget, AsTarget extends any ? React.ComponentPropsWithRef<...> : {}, ForwardedAsTarget extends any ? React.ComponentPropsWithRef<...> : {}>",
         },
       ]
@@ -583,6 +615,7 @@ describe('getTypeDocumentation', () => {
               "name": "$gridTemplateColumns",
               "properties": null,
               "required": true,
+              "tags": [],
               "text": "string",
             },
             {
@@ -591,10 +624,12 @@ describe('getTypeDocumentation', () => {
               "name": "$gridTemplateRows",
               "properties": null,
               "required": true,
+              "tags": [],
               "text": "string",
             },
           ],
           "required": true,
+          "tags": [],
           "text": "PolymorphicComponentProps<"web", Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, { $gridTemplateColumns: string; $gridTemplateRows: string; }>, AsTarget, ForwardedAsTarget, AsTarget extends any ? React.ComponentPropsWithRef<...> : {}, ForwardedAsTarget extends any ? React.Co...",
         },
       ]

--- a/packages/utils/src/types/getTypeDocumentation.ts
+++ b/packages/utils/src/types/getTypeDocumentation.ts
@@ -6,10 +6,13 @@ import type {
   CallExpression,
   Symbol,
   Type,
-  ts,
 } from 'ts-morph'
-import { Node, SyntaxKind, TypeFormatFlags, TypeChecker } from 'ts-morph'
-import { getDefaultValuesFromProperties, getSymbolDescription } from '../index'
+import { ts, Node, SyntaxKind, TypeFormatFlags, TypeChecker } from 'ts-morph'
+import {
+  getDefaultValuesFromProperties,
+  getSymbolDescription,
+  getSymbolTags,
+} from '../index'
 
 /** Analyzes metadata and parameter types from functions, tagged templates, and call expressions. */
 export function getTypeDocumentation(
@@ -73,6 +76,7 @@ function processParameterType(parameter: Symbol, enclosingNode: Node) {
   const metadata: {
     name: string | null
     description: string | null
+    tags: Array<{ name: string; text: string }>
     defaultValue: any
     required: boolean
     text: string
@@ -85,6 +89,7 @@ function processParameterType(parameter: Symbol, enclosingNode: Node) {
     required,
     name: isObjectBindingPattern ? null : parameter.getName(),
     description: getSymbolDescription(parameter),
+    tags: getSymbolTags(parameter),
     text: parameter
       .getTypeAtLocation(enclosingNode)
       .getText(
@@ -155,6 +160,7 @@ function processParameterType(parameter: Symbol, enclosingNode: Node) {
 export interface PropertyMetadata {
   name: string | null
   description: string | null
+  tags: Array<{ name: string; text: string }>
   defaultValue: any
   required: boolean
   text: string
@@ -222,6 +228,7 @@ function processTypeProperties(
       {
         name: null,
         description: null,
+        tags: [],
         defaultValue: undefined,
         required: true,
         text: type.getText(
@@ -294,6 +301,7 @@ function processProperty(
     defaultValue,
     name: propertyName,
     description: getSymbolDescription(property),
+    tags: getSymbolTags(property),
     required: Node.isPropertySignature(primaryDeclaration)
       ? !primaryDeclaration.hasQuestionToken() && !defaultValue
       : !defaultValue,

--- a/site/public/tsxmod-utils.d.ts
+++ b/site/public/tsxmod-utils.d.ts
@@ -46,6 +46,9 @@ declare function getImportDeclaration(sourceFile: SourceFile, moduleSpecifier: s
  */
 declare function getImportSpecifier(sourceFile: SourceFile, moduleSpecifier: string, importSpecifier: string): ImportSpecifier | undefined;
 
+/** Determines if a node has a specific JSDoc tag present. */
+declare function hasJsDocTag(node: Node, tagName: string): boolean;
+
 /** Finds the closest component declaration starting from a node. */
 declare function findClosestComponentDeclaration(node: Node): Node | undefined;
 
@@ -124,15 +127,22 @@ declare function getReactFunctionDeclaration(declaration: Node): ArrowFunction |
 /** Determines if an expression is using React.forwardRef. */
 declare function isForwardRefExpression(node: Node): node is CallExpression;
 
-/** Gets the description from a symbol's jsdocs or leading comment range. */
+/** Gets the description from a symbol's JSDoc or leading comment range. */
 declare function getSymbolDescription(symbol: Symbol): string | null;
+
+/** Gets the tags from a symbol's JSDoc. */
+declare function getSymbolTags(symbol: Symbol): {
+    name: string;
+    text: string;
+}[];
 
 /** Modifies a source file to add computed types to all eligible type aliases. */
 declare function addComputedTypes(sourceFile: SourceFile): void;
 
 /**
- * Get the computed quick info at a position in a source file.
- * Note, this will modify the source file by adding computed types.
+ * Get the computed quick info at a position in a source file. This is similar to `getQuickInfoAtPosition`
+ * using the language service, but it will also flatten types. Note, type source files will be modified
+ * using `addComputedTypes`.
  */
 declare function getComputedQuickInfoAtPosition(sourceFile: SourceFile, position: number): ts.QuickInfo | undefined;
 
@@ -140,6 +150,10 @@ declare function getComputedQuickInfoAtPosition(sourceFile: SourceFile, position
 declare function getTypeDocumentation(declarationOrExpression: FunctionDeclaration | FunctionExpression | ArrowFunction | TaggedTemplateExpression | CallExpression): {
     name: string | null;
     description: string | null;
+    tags: {
+        name: string;
+        text: string;
+    }[];
     defaultValue: any;
     required: boolean;
     text: string;
@@ -149,6 +163,10 @@ declare function getTypeDocumentation(declarationOrExpression: FunctionDeclarati
 interface PropertyMetadata {
     name: string | null;
     description: string | null;
+    tags: Array<{
+        name: string;
+        text: string;
+    }>;
     defaultValue: any;
     required: boolean;
     text: string;
@@ -156,4 +174,4 @@ interface PropertyMetadata {
     unionProperties?: PropertyMetadata[][];
 }
 
-export { type PropertyMetadata, TreeMode, addComputedTypes, extractExportByIdentifier, findClosestComponentDeclaration, findNamedImportReferences, findReferencesAsJsxElements, findReferencesInSourceFile, findRootComponentReferences, getChildrenFunction, getClassNamesForJsxElement, getComputedQuickInfoAtPosition, getDefaultValuesFromProperties, getDescendantAtRange, getDiagnosticMessageText, getImportClause, getImportDeclaration, getImportSpecifier, getJsxElement, getJsxElements, getPropTypes, getReactFunctionDeclaration, getSymbolDescription, getTypeDeclarationsFromProject, getTypeDocumentation, isForwardRefExpression, isJsxComponent, renameJsxIdentifier, resolveExpression, resolveJsxAttributeValue, resolveObject };
+export { type PropertyMetadata, TreeMode, addComputedTypes, extractExportByIdentifier, findClosestComponentDeclaration, findNamedImportReferences, findReferencesAsJsxElements, findReferencesInSourceFile, findRootComponentReferences, getChildrenFunction, getClassNamesForJsxElement, getComputedQuickInfoAtPosition, getDefaultValuesFromProperties, getDescendantAtRange, getDiagnosticMessageText, getImportClause, getImportDeclaration, getImportSpecifier, getJsxElement, getJsxElements, getPropTypes, getReactFunctionDeclaration, getSymbolDescription, getSymbolTags, getTypeDeclarationsFromProject, getTypeDocumentation, hasJsDocTag, isForwardRefExpression, isJsxComponent, renameJsxIdentifier, resolveExpression, resolveJsxAttributeValue, resolveObject };


### PR DESCRIPTION
This PR added `jsDocTags` to propType, which will be very useful from component API migration, updated the show case how to use it

This is my first time to use ts-morph, feel free to edit the PR 😄 