### PR TITLE
add filterProperty to getTypeDocumentation

### DIFF
--- a/.changeset/bright-dancers-kick.md
+++ b/.changeset/bright-dancers-kick.md
@@ -1,0 +1,5 @@
+---
+"@tsxmod/utils": minor
+---
+
+Adds `filterProperty` to `getTypeDocumentation` to allow granular control of which properties are processed.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,9 +35,11 @@
     "ts-morph": ">=17.0.0"
   },
   "devDependencies": {
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
     "clsx": "2.1.1",
     "dedent": "1.5.3",
-    "ts-morph": "^22.0.0",
-    "styled-components": "6.1.11"
+    "styled-components": "6.1.11",
+    "ts-morph": "^22.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,12 @@ importers:
 
   packages/utils:
     devDependencies:
+      '@types/react':
+        specifier: 18.3.3
+        version: 18.3.3
+      '@types/react-dom':
+        specifier: 18.3.0
+        version: 18.3.0
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -1712,7 +1718,7 @@ packages:
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
     dependencies:
       '@types/prop-types': 15.7.5
-      csstype: 3.1.2
+      csstype: 3.1.3
     dev: true
 
   /@types/semver@7.5.6:
@@ -2358,10 +2364,6 @@ packages:
       camelize: 1.0.1
       css-color-keywords: 1.0.0
       postcss-value-parser: 4.2.0
-    dev: true
-
-  /csstype@3.1.2:
-    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
     dev: true
 
   /csstype@3.1.3:

--- a/site/public/tsxmod-utils.d.ts
+++ b/site/public/tsxmod-utils.d.ts
@@ -1,5 +1,5 @@
 import * as ts_morph from 'ts-morph';
-import { DiagnosticMessageChain, SourceFile, Expression, Identifier, Node, Project, ts, ImportClause, ImportDeclaration, ImportSpecifier, JsxOpeningElement, JsxSelfClosingElement, JsxElement, VariableDeclaration, FunctionDeclaration, FunctionExpression, ArrowFunction, ClassDeclaration, JsxAttribute, ObjectLiteralExpression, BindingElement, ParameterDeclaration, PropertyAssignment, CallExpression, Symbol, InterfaceDeclaration, TypeAliasDeclaration } from 'ts-morph';
+import { DiagnosticMessageChain, SourceFile, Expression, Identifier, Node, Project, ts, ImportClause, ImportDeclaration, ImportSpecifier, JsxOpeningElement, JsxSelfClosingElement, JsxElement, VariableDeclaration, FunctionDeclaration, FunctionExpression, ArrowFunction, ClassDeclaration, JsxAttribute, ObjectLiteralExpression, BindingElement, ParameterDeclaration, PropertyAssignment, CallExpression, Symbol, InterfaceDeclaration, TypeAliasDeclaration, PropertySignature } from 'ts-morph';
 
 /** Parses a diagnostic message into a string. */
 declare function getDiagnosticMessageText(message: string | DiagnosticMessageChain): string;
@@ -137,7 +137,7 @@ declare function getReactFunctionDeclaration(declaration: Node): ArrowFunction |
 declare function isForwardRefExpression(node: Node): node is CallExpression;
 
 /** Gets the description from a symbol's JSDoc or leading comment range. */
-declare function getSymbolDescription(symbol: Symbol): string | null;
+declare function getSymbolDescription(symbol: Symbol): string | undefined;
 
 /** Modifies a source file to add computed types to all eligible type aliases and interfaces. */
 declare function addComputedTypes(sourceFile: SourceFile): void;
@@ -150,14 +150,108 @@ declare function addComputedTypes(sourceFile: SourceFile): void;
 declare function getComputedQuickInfoAtPosition(sourceFile: SourceFile, position: number): ts.QuickInfo | undefined;
 
 /** Analyzes metadata from interfaces, type aliases, classes, functions, and variable declarations. */
-declare function getTypeDocumentation(declaration: InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | FunctionDeclaration | VariableDeclaration): any;
+declare function getTypeDocumentation(declaration: InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | FunctionDeclaration | VariableDeclaration, propertyFilter?: (property: PropertySignature) => boolean): {
+    description?: string | undefined;
+    tags?: {
+        tagName: string;
+        text?: string | undefined;
+    }[] | undefined;
+    name: string;
+    properties: PropertyMetadata[];
+} | {
+    name?: string | undefined;
+    constructor?: {
+        name: string;
+        parameters?: {
+            name?: string | undefined;
+            description?: string | undefined;
+            defaultValue?: any;
+            required: boolean;
+            type: string;
+            properties?: PropertyMetadata[] | undefined;
+            unionProperties?: PropertyMetadata[][] | undefined;
+        }[] | undefined;
+        description?: string | undefined;
+        tags?: {
+            tagName: string;
+            text?: string | undefined;
+        }[] | undefined;
+    } | undefined;
+    accessors?: {
+        returnType: string;
+        name: string;
+        description: string | undefined;
+        modifier: string | undefined;
+        scope: string | undefined;
+        visibility: string | undefined;
+        type: string;
+        parameters?: {
+            name?: string | undefined;
+            description?: string | undefined;
+            defaultValue?: any;
+            required: boolean;
+            type: string;
+            properties?: PropertyMetadata[] | undefined;
+            unionProperties?: PropertyMetadata[][] | undefined;
+        }[] | undefined;
+    }[] | undefined;
+    methods?: {
+        parameters: {
+            name?: string | undefined;
+            description?: string | undefined;
+            defaultValue?: any;
+            required: boolean;
+            type: string;
+            properties?: PropertyMetadata[] | undefined;
+            unionProperties?: PropertyMetadata[][] | undefined;
+        }[];
+        name: string;
+        description: string | undefined;
+        modifier: string | undefined;
+        scope: string | undefined;
+        visibility: string | undefined;
+        type: string;
+        returnType: string;
+    }[] | undefined;
+    properties?: {
+        name: string;
+        description: string | undefined;
+        scope: string | undefined;
+        visibility: string | undefined;
+        isReadonly: boolean;
+        type: string;
+    }[] | undefined;
+    description?: string | undefined;
+    tags?: {
+        tagName: string;
+        text?: string | undefined;
+    }[] | undefined;
+} | {
+    description?: string | undefined;
+    tags?: {
+        tagName: string;
+        text?: string | undefined;
+    }[] | undefined;
+    name: string | undefined;
+    parameters: {
+        name?: string | undefined;
+        description?: string | undefined;
+        defaultValue?: any;
+        required: boolean;
+        type: string;
+        properties?: PropertyMetadata[] | undefined;
+        unionProperties?: PropertyMetadata[][] | undefined;
+    }[];
+    type: string;
+    returnType: string;
+} | undefined;
 interface PropertyMetadata {
-    name: string | null;
-    description: string | null;
-    defaultValue: any;
+    name?: string;
+    description?: string;
+    defaultValue?: any;
     required: boolean;
     type: string;
-    properties: (PropertyMetadata | null)[] | null;
+    properties?: (PropertyMetadata | null)[];
     unionProperties?: PropertyMetadata[][];
 }
 


### PR DESCRIPTION
This adds the ability to filter specific properties in `getTypeDocumentation` by passing a custom filter. Take the following source file:

```tsx
import * as React from 'react';

type ButtonVariant = 'primary' | 'secondary' | 'danger';

type ButtonProps = {
  variant?: ButtonVariant;
} & React.ButtonHTMLAttributes<HTMLButtonElement>

export const Button = (props: ButtonProps) => {
  return <button {...props} />
};
```

When processing documentation from this source file, a filter can now be provided to allow specific properties from `node_modules` to be processed for documentation:

```ts
const types = getTypeDocumentation(
  sourceFile.getVariableDeclarationOrThrow('Button'),
  (property) => {
    if (property.getName() === 'onClick') {
      return true
    }
    return !property.getSourceFile().isInNodeModules()
  }
)
```