### PR TITLE
support function type documentation

### DIFF
--- a/.changeset/stupid-boxes-dream.md
+++ b/.changeset/stupid-boxes-dream.md
@@ -1,0 +1,5 @@
+---
+"@tsxmod/utils": minor
+---
+
+Adds support for function type documentation in `getTypeDocumentation`.

--- a/packages/utils/src/types/getTypeDocumentation.test.ts
+++ b/packages/utils/src/types/getTypeDocumentation.test.ts
@@ -1054,4 +1054,106 @@ describe('getTypeDocumentation', () => {
       }
     `)
   })
+
+  test('function types', () => {
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      import * as React from 'react';
+
+      export function getExportedTypes() {
+        return [
+          { 
+            /** The name of the component. */ 
+            name: 'Button',
+
+            /** The description of the component. */
+            description: 'A button component' 
+          }
+        ]
+      }
+      
+      type BaseExportedTypesProps = {
+        /** Controls how types are rendered. */
+        children?: (
+          exportedTypes: ReturnType<typeof getExportedTypes>
+        ) => React.ReactNode
+      }
+
+      type ExportedTypesProps =
+        | ({ source: string } & BaseExportedTypesProps)
+        | ({ filename: string; value: string } & BaseExportedTypesProps)
+      
+      function ExportedTypes({ children }: ExportedTypesProps) {}
+      `,
+      { overwrite: true }
+    )
+    const types = getTypeDocumentation(
+      sourceFile.getFunctionOrThrow('ExportedTypes')
+    )
+
+    expect(types).toMatchInlineSnapshot(`
+      {
+        "name": "ExportedTypes",
+        "parameters": [
+          {
+            "defaultValue": undefined,
+            "description": undefined,
+            "name": undefined,
+            "properties": [
+              {
+                "defaultValue": undefined,
+                "description": "Controls how types are rendered.",
+                "name": "children",
+                "parameters": [
+                  {
+                    "defaultValue": undefined,
+                    "description": undefined,
+                    "name": "exportedTypes",
+                    "required": true,
+                    "type": "{ name: string; description: string; }[]",
+                  },
+                ],
+                "required": false,
+                "returnType": "React.ReactNode",
+                "tags": undefined,
+                "type": "(exportedTypes: ReturnType<typeof getExportedTypes>) => React.ReactNode",
+              },
+            ],
+            "required": true,
+            "type": "ExportedTypesProps",
+            "unionProperties": [
+              [
+                {
+                  "defaultValue": undefined,
+                  "description": undefined,
+                  "name": "source",
+                  "required": true,
+                  "type": "string",
+                },
+              ],
+              [
+                {
+                  "defaultValue": undefined,
+                  "description": undefined,
+                  "name": "filename",
+                  "required": true,
+                  "type": "string",
+                },
+                {
+                  "defaultValue": undefined,
+                  "description": undefined,
+                  "name": "value",
+                  "required": true,
+                  "type": "string",
+                },
+              ],
+            ],
+          },
+        ],
+        "returnType": "void",
+        "type": "({ children }: ExportedTypesProps) => void",
+      }
+    `)
+  })
 })


### PR DESCRIPTION
Adds support for function type documentation in `getTypeDocumentation` by parsing properties that are `FunctionType`. This can be the case for several reasons, but came up when documenting child functions in React:

```ts
import * as React from 'react';

function getExportedTypes() {
  return [
    { 
      /** The name of the component. */ 
      name: 'Button',

      /** The description of the component. */
      description: 'A button component' 
    }
  ]
}

type ExportedTypesProps = {
  /** Controls how types are rendered. */
  children?: (
    exportedTypes: ReturnType<typeof getExportedTypes>
  ) => React.ReactNode
}

function ExportedTypes({ children }: ExportedTypesProps) {}
```

Is now parsed as:

```json
{
  "name": "ExportedTypes",
  "parameters": [
    {
      "properties": [
        {
          "description": "Controls how types are rendered.",
          "name": "children",
          "parameters": [
            {
              "name": "exportedTypes",
              "type": "{ name: string; description: string; }[]",
            },
          ],
          "required": false,
          "returnType": "React.ReactNode",
          "type": "(exportedTypes: ReturnType<typeof getExportedTypes>) => React.ReactNode",
        },
      ],
      "required": true,
      "type": "ExportedTypesProps",
   }
 ]
}
```

This will still include unrelated fields like `defaultValues`, `required` etc since this is utilizing the same utility to unwrap normal function arguments. An additional function type arguments utility can be handled in a follow-up.