### PR TITLE
add processType utility

### DIFF
--- a/.changeset/brave-carrots-taste.md
+++ b/.changeset/brave-carrots-taste.md
@@ -1,0 +1,5 @@
+---
+'@tsxmod/utils': minor
+---
+
+Introduces a new `processType` utility designed to improve the robustness of parsing types in complex scenarios.

--- a/packages/utils/src/properties/getDefaultValuesFromProperties.ts
+++ b/packages/utils/src/properties/getDefaultValuesFromProperties.ts
@@ -1,7 +1,10 @@
 import type {
   BindingElement,
+  MethodSignature,
   ParameterDeclaration,
   PropertyAssignment,
+  PropertyDeclaration,
+  PropertySignature,
 } from 'ts-morph'
 import { Node } from 'ts-morph'
 
@@ -11,20 +14,51 @@ import {
   type LiteralExpressionValue,
 } from '../expressions'
 
+export function getDefaultValueKey(
+  property:
+    | BindingElement
+    | ParameterDeclaration
+    | PropertyDeclaration
+    | PropertyAssignment
+    | PropertySignature
+    | MethodSignature
+) {
+  return Node.isBindingElement(property)
+    ? property.getPropertyNameNode()?.getText() || property.getName()
+    : property.getName()
+}
+
 /** Gets the default values for a set of properties. */
 export function getDefaultValuesFromProperties(
-  properties: Array<BindingElement | ParameterDeclaration | PropertyAssignment>
+  properties: Array<
+    | BindingElement
+    | ParameterDeclaration
+    | PropertyDeclaration
+    | PropertyAssignment
+    | PropertySignature
+    | MethodSignature
+  >
 ) {
   const defaultValues: Record<string, LiteralExpressionValue> = {}
 
   properties.forEach((property) => {
-    if (Node.isSpreadAssignment(property) || !property.getNameNode()) {
+    if (
+      Node.isSpreadAssignment(property) ||
+      Node.isMethodSignature(property) ||
+      !property.getNameNode()
+    ) {
       return
     }
 
-    const name = Node.isBindingElement(property)
-      ? property.getPropertyNameNode()?.getText() || property.getName()
-      : property.getName()
+    const name = getDefaultValueKey(property)
+    const kindName = property.getKindName()
+
+    if (!('getInitializer' in property)) {
+      throw new Error(
+        `[getDefaultValuesFromProperties] Property "${name}" of kind "${kindName}" does not have an initializer, so it cannot have a default value. This declaration should be filtered or file an issue for support.`
+      )
+    }
+
     const initializer = property.getInitializer()
 
     if (initializer) {

--- a/packages/utils/src/properties/index.ts
+++ b/packages/utils/src/properties/index.ts
@@ -1,1 +1,4 @@
-export { getDefaultValuesFromProperties } from './getDefaultValuesFromProperties'
+export {
+  getDefaultValueKey,
+  getDefaultValuesFromProperties,
+} from './getDefaultValuesFromProperties'

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -1,0 +1,707 @@
+import { Project } from 'ts-morph'
+import { processTypeProperties, processType } from './processType'
+
+describe('processProperties', () => {
+  const project = new Project()
+
+  const sourceFile = project.createSourceFile(
+    'sample.ts',
+    `
+  export type ExportedType = {
+    slug: string;
+    filePath: string;
+  };
+
+  export type ModuleData = {
+    method(parameterValue: { objectValue: number }): Promise<number>;
+    exportedTypes: Array<ExportedType>;
+  };
+
+  export type FunctionType = (param1: string, param2: number) => Promise<ExportedType>;
+
+  const foo = async () => {
+    return {
+      slug: 'foo',
+      filePath: 'bar',
+    }
+  }
+
+  export type ComplexType = {
+    promiseObject: Promise<ExportedType>;
+    promiseFunction: Promise<(a: number, b: string) => void>;
+    promiseVariable: ReturnType<typeof foo>;
+    union: string | number;
+    complexUnion: ((a: string) => string | number) | { a: string } | { b: number, c: (string | number)[] } | string;
+    intersection: { a: string } & { b: number };
+    complexIntersection: ReturnType<FunctionType> & { a: string } & { b(): void };
+    tuple: [a: string, b: number, string];
+    function: FunctionType;
+  };
+`
+  )
+
+  test('process generic properties', () => {
+    const typeAlias = sourceFile.getTypeAliasOrThrow('ModuleData')
+    const processedProperties = processType(typeAlias.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": "ModuleData",
+        "properties": [
+          {
+            "kind": "Function",
+            "name": "method",
+            "signatures": [
+              {
+                "parameters": [
+                  {
+                    "description": undefined,
+                    "kind": "Object",
+                    "name": "parameterValue",
+                    "properties": [
+                      {
+                        "kind": "Number",
+                        "name": "objectValue",
+                        "type": "number",
+                      },
+                    ],
+                    "type": "{ objectValue: number; }",
+                  },
+                ],
+                "returnType": "Promise<number>",
+                "type": "(parameterValue: { objectValue: number; }) => Promise<number>",
+              },
+            ],
+            "type": "(parameterValue: { objectValue: number; }) => Promise<number>",
+          },
+          {
+            "kind": "Array",
+            "name": "exportedTypes",
+            "type": {
+              "kind": "Object",
+              "name": "ExportedType",
+              "properties": [
+                {
+                  "kind": "String",
+                  "name": "slug",
+                  "type": "string",
+                },
+                {
+                  "kind": "String",
+                  "name": "filePath",
+                  "type": "string",
+                },
+              ],
+              "type": "ExportedType",
+            },
+          },
+        ],
+        "type": "ModuleData",
+      }
+    `)
+  })
+
+  test('complex properties', () => {
+    const typeAlias = sourceFile.getTypeAliasOrThrow('ComplexType')
+    const type = typeAlias.getType()
+    const processedProperties = processTypeProperties(type)
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "Promise",
+          "name": "promiseObject",
+          "type": {
+            "kind": "Object",
+            "name": "ExportedType",
+            "properties": [
+              {
+                "kind": "String",
+                "name": "slug",
+                "type": "string",
+              },
+              {
+                "kind": "String",
+                "name": "filePath",
+                "type": "string",
+              },
+            ],
+            "type": "ExportedType",
+          },
+        },
+        {
+          "kind": "Promise",
+          "name": "promiseFunction",
+          "type": {
+            "kind": "Function",
+            "name": undefined,
+            "signatures": [
+              {
+                "parameters": [
+                  {
+                    "description": undefined,
+                    "kind": "Number",
+                    "name": "a",
+                    "type": "number",
+                  },
+                  {
+                    "description": undefined,
+                    "kind": "String",
+                    "name": "b",
+                    "type": "string",
+                  },
+                ],
+                "returnType": "void",
+                "type": "(a: number, b: string) => void",
+              },
+            ],
+            "type": "(a: number, b: string) => void",
+          },
+        },
+        {
+          "kind": "Promise",
+          "name": "promiseVariable",
+          "type": {
+            "kind": "Object",
+            "name": undefined,
+            "properties": [
+              {
+                "kind": "String",
+                "name": "slug",
+                "type": "string",
+              },
+              {
+                "kind": "String",
+                "name": "filePath",
+                "type": "string",
+              },
+            ],
+            "type": "{ slug: string; filePath: string; }",
+          },
+        },
+        {
+          "kind": "Union",
+          "name": "union",
+          "properties": [
+            {
+              "kind": "String",
+              "type": "string",
+            },
+            {
+              "kind": "Number",
+              "type": "number",
+            },
+          ],
+          "type": "string | number",
+        },
+        {
+          "kind": "Union",
+          "name": "complexUnion",
+          "properties": [
+            {
+              "kind": "String",
+              "type": "string",
+            },
+            {
+              "kind": "Function",
+              "name": undefined,
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "description": undefined,
+                      "kind": "String",
+                      "name": "a",
+                      "type": "string",
+                    },
+                  ],
+                  "returnType": "string | number",
+                  "type": "(a: string) => string | number",
+                },
+              ],
+              "type": "(a: string) => string | number",
+            },
+            {
+              "kind": "Object",
+              "name": undefined,
+              "properties": [
+                {
+                  "kind": "String",
+                  "name": "a",
+                  "type": "string",
+                },
+              ],
+              "type": "{ a: string; }",
+            },
+            {
+              "kind": "Object",
+              "name": undefined,
+              "properties": [
+                {
+                  "kind": "Number",
+                  "name": "b",
+                  "type": "number",
+                },
+                {
+                  "kind": "Array",
+                  "name": "c",
+                  "type": {
+                    "kind": "Union",
+                    "name": undefined,
+                    "properties": [
+                      {
+                        "kind": "String",
+                        "type": "string",
+                      },
+                      {
+                        "kind": "Number",
+                        "type": "number",
+                      },
+                    ],
+                    "type": "string | number",
+                  },
+                },
+              ],
+              "type": "{ b: number; c: (string | number)[]; }",
+            },
+          ],
+          "type": "string | ((a: string) => string | number) | { a: string; } | { b: number; c: (string | number)[]; }",
+        },
+        {
+          "kind": "Intersection",
+          "name": "intersection",
+          "properties": [
+            {
+              "kind": "Object",
+              "name": undefined,
+              "properties": [
+                {
+                  "kind": "String",
+                  "name": "a",
+                  "type": "string",
+                },
+              ],
+              "type": "{ a: string; }",
+            },
+            {
+              "kind": "Object",
+              "name": undefined,
+              "properties": [
+                {
+                  "kind": "Number",
+                  "name": "b",
+                  "type": "number",
+                },
+              ],
+              "type": "{ b: number; }",
+            },
+          ],
+          "type": "{ a: string; } & { b: number; }",
+        },
+        {
+          "kind": "Intersection",
+          "name": "complexIntersection",
+          "properties": [
+            {
+              "kind": "Promise",
+              "type": {
+                "kind": "Object",
+                "name": "ExportedType",
+                "properties": [
+                  {
+                    "kind": "String",
+                    "name": "slug",
+                    "type": "string",
+                  },
+                  {
+                    "kind": "String",
+                    "name": "filePath",
+                    "type": "string",
+                  },
+                ],
+                "type": "ExportedType",
+              },
+            },
+            {
+              "kind": "Object",
+              "name": undefined,
+              "properties": [
+                {
+                  "kind": "String",
+                  "name": "a",
+                  "type": "string",
+                },
+              ],
+              "type": "{ a: string; }",
+            },
+            {
+              "kind": "Object",
+              "name": undefined,
+              "properties": [
+                {
+                  "kind": "Function",
+                  "name": "b",
+                  "signatures": [
+                    {
+                      "parameters": [],
+                      "returnType": "void",
+                      "type": "() => void",
+                    },
+                  ],
+                  "type": "() => void",
+                },
+              ],
+              "type": "{ b(): void; }",
+            },
+          ],
+          "type": "Promise<ExportedType> & { a: string; } & { b(): void; }",
+        },
+        {
+          "elements": [
+            {
+              "kind": "String",
+              "name": "a",
+              "type": "string",
+            },
+            {
+              "kind": "Number",
+              "name": "b",
+              "type": "number",
+            },
+            {
+              "kind": "String",
+              "name": "string",
+              "type": "string",
+            },
+          ],
+          "kind": "Tuple",
+          "name": "tuple",
+          "type": "[a: string, b: number, string]",
+        },
+        {
+          "kind": "Function",
+          "name": "function",
+          "signatures": [
+            {
+              "parameters": [
+                {
+                  "description": undefined,
+                  "kind": "String",
+                  "name": "param1",
+                  "type": "string",
+                },
+                {
+                  "description": undefined,
+                  "kind": "Number",
+                  "name": "param2",
+                  "type": "number",
+                },
+              ],
+              "returnType": "Promise<ExportedType>",
+              "type": "(param1: string, param2: number) => Promise<ExportedType>",
+            },
+          ],
+          "type": "FunctionType",
+        },
+      ]
+    `)
+  })
+
+  test('intersection and union', () => {
+    const project = new Project()
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      `
+      export type BaseVariant = {
+        color: string;
+      }
+
+      type FillVariant = {
+        backgroundColor: string;
+      } & BaseVariant
+
+      type OutlineVariant = {
+        borderColor: string;
+      } & BaseVariant
+
+      type Variant<T> = FillVariant | OutlineVariant | string;
+    `
+    )
+    const typeAlias = sourceFile.getTypeAliasOrThrow('Variant')
+    const processedProperties = processType(typeAlias.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Union",
+        "name": "Variant",
+        "properties": [
+          {
+            "kind": "String",
+            "type": "string",
+          },
+          {
+            "kind": "Intersection",
+            "name": "FillVariant",
+            "properties": [
+              {
+                "kind": "Object",
+                "name": undefined,
+                "properties": [
+                  {
+                    "kind": "String",
+                    "name": "backgroundColor",
+                    "type": "string",
+                  },
+                ],
+                "type": "{ backgroundColor: string; }",
+              },
+              {
+                "kind": "Object",
+                "name": "BaseVariant",
+                "properties": [
+                  {
+                    "kind": "String",
+                    "name": "color",
+                    "type": "string",
+                  },
+                ],
+                "type": "BaseVariant",
+              },
+            ],
+            "type": "FillVariant",
+          },
+          {
+            "kind": "Intersection",
+            "name": "OutlineVariant",
+            "properties": [
+              {
+                "kind": "Object",
+                "name": undefined,
+                "properties": [
+                  {
+                    "kind": "String",
+                    "name": "borderColor",
+                    "type": "string",
+                  },
+                ],
+                "type": "{ borderColor: string; }",
+              },
+              {
+                "kind": "Object",
+                "name": "BaseVariant",
+                "properties": [
+                  {
+                    "kind": "String",
+                    "name": "color",
+                    "type": "string",
+                  },
+                ],
+                "type": "BaseVariant",
+              },
+            ],
+            "type": "OutlineVariant",
+          },
+        ],
+        "type": "Variant<T>",
+      }
+    `)
+  })
+
+  test('primitives', () => {
+    const project = new Project()
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      `
+      type Primitives = {
+        /** a string */
+        str: string;
+        /**
+         * a number
+         * @internal
+         */
+        num: number;
+        /* no js doc */
+        bool: boolean;
+        /** Accepts a string */
+        func: (
+          /** a string parameter */
+          a: string,
+        ) => void;
+        arr: string[];
+        obj: Record<string, any>;
+      }
+    `
+    )
+    const typeAlias = sourceFile.getTypeAliasOrThrow('Primitives')
+    const processedProperties = processType(typeAlias.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": "Primitives",
+        "properties": [
+          {
+            "description": "a string",
+            "kind": "String",
+            "name": "str",
+            "tags": undefined,
+            "type": "string",
+          },
+          {
+            "description": "
+      a number",
+            "kind": "Number",
+            "name": "num",
+            "tags": [
+              {
+                "tagName": "internal",
+                "text": undefined,
+              },
+            ],
+            "type": "number",
+          },
+          {
+            "kind": "Boolean",
+            "name": "bool",
+            "type": "boolean",
+          },
+          {
+            "description": "Accepts a string",
+            "kind": "Function",
+            "name": "func",
+            "signatures": [
+              {
+                "parameters": [
+                  {
+                    "description": "a string parameter",
+                    "kind": "String",
+                    "name": "a",
+                    "type": "string",
+                  },
+                ],
+                "returnType": "void",
+                "type": "(a: string) => void",
+              },
+            ],
+            "tags": undefined,
+            "type": "(a: string) => void",
+          },
+          {
+            "kind": "Array",
+            "name": "arr",
+            "type": {
+              "kind": "String",
+              "type": "string",
+            },
+          },
+          {
+            "kind": "Object",
+            "name": "obj",
+            "properties": [],
+            "type": "Record<string, any>",
+          },
+        ],
+        "type": "Primitives",
+      }
+    `)
+  })
+
+  test('variable declarations', () => {
+    const project = new Project()
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      `
+      const a = {
+        b: 1,
+        c: 'string',
+        ...d
+      } as const
+
+      const d = {
+        e: {
+          f: 1,
+        },
+        g: 'string',
+      }
+    `
+    )
+    const variableDeclaration = sourceFile.getVariableDeclarationOrThrow('a')
+    const processedProperties = processType(variableDeclaration.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": undefined,
+        "properties": [
+          {
+            "kind": "Object",
+            "name": "e",
+            "properties": [
+              {
+                "kind": "Number",
+                "name": "f",
+                "type": "number",
+              },
+            ],
+            "type": "{ f: number; }",
+          },
+          {
+            "kind": "String",
+            "name": "g",
+            "type": "string",
+          },
+          {
+            "kind": "Literal",
+            "name": "b",
+            "type": "1",
+          },
+          {
+            "kind": "Literal",
+            "name": "c",
+            "type": ""string"",
+          },
+        ],
+        "type": "{ readonly e: { f: number; }; readonly g: string; readonly b: 1; readonly c: "string"; }",
+      }
+    `)
+  })
+
+  test('recursive types', () => {
+    const project = new Project()
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      `
+      type SelfReferencedType = {
+        id: string;
+        children: SelfReferencedType[];
+      }
+    `
+    )
+    const typeAlias = sourceFile.getTypeAliasOrThrow('SelfReferencedType')
+    const processedProperties = processType(typeAlias.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": "SelfReferencedType",
+        "properties": [
+          {
+            "kind": "String",
+            "name": "id",
+            "type": "string",
+          },
+          {
+            "kind": "Array",
+            "name": "children",
+            "type": {
+              "kind": "Reference",
+              "type": "SelfReferencedType",
+            },
+          },
+        ],
+        "type": "SelfReferencedType",
+      }
+    `)
+  })
+})

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -271,7 +271,7 @@ describe('processProperties', () => {
         },
         {
           "isOptional": false,
-          "kind": "Intersection",
+          "kind": "Object",
           "name": "intersection",
           "properties": [
             {
@@ -305,7 +305,7 @@ describe('processProperties', () => {
         },
         {
           "isOptional": false,
-          "kind": "Intersection",
+          "kind": "Object",
           "name": "complexIntersection",
           "properties": [
             {
@@ -443,7 +443,7 @@ describe('processProperties', () => {
             "type": "string",
           },
           {
-            "kind": "Intersection",
+            "kind": "Object",
             "name": "FillVariant",
             "properties": [
               {
@@ -467,7 +467,7 @@ describe('processProperties', () => {
             "type": "FillVariant",
           },
           {
-            "kind": "Intersection",
+            "kind": "Object",
             "name": "OutlineVariant",
             "properties": [
               {
@@ -982,7 +982,7 @@ describe('processProperties', () => {
 
     expect(types).toMatchInlineSnapshot(`
       {
-        "kind": "Intersection",
+        "kind": "Object",
         "name": "TextProps",
         "properties": [
           {
@@ -1084,7 +1084,7 @@ describe('processProperties', () => {
               "name": "ExportedType",
               "properties": [
                 {
-                  "kind": "Intersection",
+                  "kind": "Object",
                   "name": undefined,
                   "properties": [
                     {
@@ -1108,7 +1108,7 @@ describe('processProperties', () => {
                   "type": "FunctionMetadata & { slug: string; }",
                 },
                 {
-                  "kind": "Intersection",
+                  "kind": "Object",
                   "name": undefined,
                   "properties": [
                     {
@@ -1223,7 +1223,7 @@ describe('processProperties', () => {
               {
                 "description": undefined,
                 "isOptional": true,
-                "kind": "Interface",
+                "kind": "Object",
                 "name": "props",
                 "properties": [
                   {

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -1516,4 +1516,64 @@ describe('processProperties', () => {
       }
     `)
   })
+
+  test('generic function parameters', () => {
+    const project = new Project()
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      const createComponent = (
+        <Props extends Record<string, any>>(tagName: string) => (props: Props) => {}
+      )
+      
+      type GridProps = { columns: number, rows: number }
+      
+      const Grid = createComponent<GridProps>('div')
+      `,
+      { overwrite: true }
+    )
+    const functionDeclaration = sourceFile.getVariableDeclarationOrThrow('Grid')
+    const processedProperties = processType(functionDeclaration.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Function",
+        "name": undefined,
+        "signatures": [
+          {
+            "modifier": undefined,
+            "parameters": [
+              {
+                "defaultValue": undefined,
+                "description": undefined,
+                "isOptional": false,
+                "kind": "Object",
+                "name": "props",
+                "properties": [
+                  {
+                    "defaultValue": undefined,
+                    "isOptional": false,
+                    "kind": "Number",
+                    "name": "columns",
+                    "type": "number",
+                  },
+                  {
+                    "defaultValue": undefined,
+                    "isOptional": false,
+                    "kind": "Number",
+                    "name": "rows",
+                    "type": "number",
+                  },
+                ],
+                "type": "GridProps",
+              },
+            ],
+            "returnType": "void",
+            "type": "(props: GridProps) => void",
+          },
+        ],
+        "type": "(props: GridProps) => void",
+      }
+    `)
+  })
 })

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -920,7 +920,7 @@ describe('processProperties', () => {
       dedent`
       import type { Color } from 'library';
 
-      type DropDollarPrefix<T> = {
+      export type DropDollarPrefix<T> = {
         [K in keyof T as K extends \`$\${infer I}\` ? I : K]: T[K]
       }
       

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -2,11 +2,11 @@ import { Project } from 'ts-morph'
 import { processTypeProperties, processType } from './processType'
 import dedent from 'dedent'
 
-describe('processProperties', () => {
-  const project = new Project()
+const project = new Project()
 
+describe('processProperties', () => {
   const sourceFile = project.createSourceFile(
-    'sample.ts',
+    'test.ts',
     `
   export type ExportedType = {
     slug: string;
@@ -415,7 +415,6 @@ describe('processProperties', () => {
   })
 
   test('intersection and union', () => {
-    const project = new Project()
     const sourceFile = project.createSourceFile(
       'test.ts',
       `
@@ -432,7 +431,8 @@ describe('processProperties', () => {
       } & BaseVariant
 
       type Variant<T> = FillVariant | OutlineVariant | string;
-    `
+    `,
+      { overwrite: true }
     )
     const typeAlias = sourceFile.getTypeAliasOrThrow('Variant')
     const processedProperties = processType(typeAlias.getType())
@@ -489,7 +489,6 @@ describe('processProperties', () => {
   })
 
   test('primitives', () => {
-    const project = new Project()
     const sourceFile = project.createSourceFile(
       'test.ts',
       `
@@ -520,7 +519,8 @@ describe('processProperties', () => {
       }
 
       async function foo() {}
-    `
+    `,
+      { overwrite: true }
     )
     const typeAlias = sourceFile.getTypeAliasOrThrow('Primitives')
     const processedProperties = processType(typeAlias.getType())
@@ -646,7 +646,6 @@ describe('processProperties', () => {
   })
 
   test('variable declarations', () => {
-    const project = new Project()
     const sourceFile = project.createSourceFile(
       'test.ts',
       `
@@ -662,7 +661,8 @@ describe('processProperties', () => {
         },
         g: 'string',
       }
-    `
+    `,
+      { overwrite: true }
     )
     const variableDeclaration = sourceFile.getVariableDeclarationOrThrow('a')
     const processedProperties = processType(variableDeclaration.getType())
@@ -716,7 +716,6 @@ describe('processProperties', () => {
   })
 
   test('recursive types', () => {
-    const project = new Project()
     const sourceFile = project.createSourceFile(
       'test.ts',
       `
@@ -724,7 +723,8 @@ describe('processProperties', () => {
         id: string;
         children: SelfReferencedType[];
       }
-    `
+    `,
+      { overwrite: true }
     )
     const typeAlias = sourceFile.getTypeAliasOrThrow('SelfReferencedType')
     const processedProperties = processType(typeAlias.getType())
@@ -798,8 +798,6 @@ describe('processProperties', () => {
   })
 
   test('avoids analyzing prototype properties and methods', () => {
-    const project = new Project()
-
     const sourceFile = project.createSourceFile(
       'test.ts',
       dedent`
@@ -810,7 +808,8 @@ describe('processProperties', () => {
       type AsyncString = {
         value: Promise<Foo>
       }
-      `
+      `,
+      { overwrite: true }
     )
 
     const typeAlias = sourceFile.getTypeAliasOrThrow('AsyncString')
@@ -851,8 +850,6 @@ describe('processProperties', () => {
   })
 
   test('unwraps generic types', () => {
-    const project = new Project()
-
     const sourceFile = project.createSourceFile(
       'test.ts',
       dedent`
@@ -880,7 +877,8 @@ describe('processProperties', () => {
       }
 
       type ExportedType = UnwrapPromisesInMap<DistributiveOmit<UnionType, 'title'>>
-      `
+      `,
+      { overwrite: true }
     )
 
     const typeAlias = sourceFile.getTypeAliasOrThrow('ExportedType')
@@ -1316,7 +1314,6 @@ describe('processProperties', () => {
   })
 
   test('default parameter values', () => {
-    const project = new Project()
     const sourceFile = project.createSourceFile(
       'test.ts',
       dedent`
@@ -1326,7 +1323,8 @@ describe('processProperties', () => {
       }
 
       export function Text(props: TextProps = { color: 'red' }) {}
-      `
+      `,
+      { overwrite: true }
     )
     const typeAlias = sourceFile.getFunctionOrThrow('Text')
     const processedProperties = processType(typeAlias.getType())
@@ -1360,7 +1358,6 @@ describe('processProperties', () => {
   })
 
   test('default object values', () => {
-    const project = new Project()
     const sourceFile = project.createSourceFile(
       'test.ts',
       dedent`
@@ -1373,7 +1370,8 @@ describe('processProperties', () => {
       }
 
       export function Text({ style: { fontSize, color } }: TextProps = { style: { fontWeight: 400, color: 'blue' } }) {}
-      `
+      `,
+      { overwrite: true }
     )
     const typeAlias = sourceFile.getFunctionOrThrow('Text')
     const processedProperties = processType(typeAlias.getType())
@@ -1445,7 +1443,6 @@ describe('processProperties', () => {
   })
 
   test('conditional generic', () => {
-    const project = new Project()
     const sourceFile = project.createSourceFile(
       'test.ts',
       dedent`
@@ -1518,7 +1515,6 @@ describe('processProperties', () => {
   })
 
   test('generic function parameters', () => {
-    const project = new Project()
     const sourceFile = project.createSourceFile(
       'test.ts',
       dedent`

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -983,131 +983,114 @@ describe('processProperties', () => {
     `)
   })
 
-  // test('simplifies complex generic types', () => {
-  //   const project = new Project()
+  test('simplifies complex generic types', () => {
+    const project = new Project()
 
-  //   project.createSourceFile(
-  //     'node_modules/@types/library/index.d.ts',
-  //     dedent`
-  //     interface SharedMetadata {
-  //       name: string;
-  //     }
+    project.createSourceFile(
+      'node_modules/@types/library/index.d.ts',
+      dedent`
+      interface SharedMetadata {
+        name: string;
+      }
 
-  //     export interface FunctionMetadata extends SharedMetadata {
-  //       parameters: Array<PropertyMetadata>;
-  //     }
+      export interface FunctionMetadata extends SharedMetadata {
+        parameters: Array<PropertyMetadata>;
+      }
 
-  //     export interface TypeMetadata extends SharedMetadata {
-  //       properties: Array<PropertyMetadata>;
-  //     }
+      export interface TypeMetadata extends SharedMetadata {
+        properties: Array<PropertyMetadata>;
+      }
 
-  //     export interface PropertyMetadata extends SharedMetadata {
-  //       type: string;
-  //     }
+      export interface PropertyMetadata extends SharedMetadata {
+        type: string;
+      }
 
-  //     export type Metadata = FunctionMetadata | TypeMetadata;
-  //     `
-  //   )
+      export type Metadata = FunctionMetadata | TypeMetadata;
+      `
+    )
 
-  //   const sourceFile = project.createSourceFile(
-  //     'test.ts',
-  //     dedent`
-  //     import type { Metadata } from 'library';
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      import type { Metadata } from 'library';
 
-  //     type ExportedType = Metadata & {
-  //       slug: string
-  //       filePath: string
-  //     }
+      type ExportedType = Metadata & { slug: string }
 
-  //     type ModuleData<Type extends { frontMatter: Record<string, any> }> = {
-  //       exportedTypes: Array<ExportedType>
-  //     }
-  //     `,
-  //     { overwrite: true }
-  //   )
-  //   const types = processType(
-  //     sourceFile.getTypeAliasOrThrow('ModuleData').getType()
-  //   )
+      type ModuleData<Type extends { frontMatter: Record<string, any> }> = {
+        exportedTypes: Array<ExportedType>
+      }
+      `,
+      { overwrite: true }
+    )
+    const types = processType(
+      sourceFile.getTypeAliasOrThrow('ModuleData').getType()
+    )
 
-  //   expect(types).toMatchInlineSnapshot(`
-  //     {
-  //       "kind": "Object",
-  //       "name": "ModuleData",
-  //       "properties": [
-  //         {
-  //           "kind": "Array",
-  //           "name": "exportedTypes",
-  //           "type": {
-  //             "kind": "Union",
-  //             "name": "ExportedType",
-  //             "properties": [
-  //               {
-  //                 "kind": "Intersection",
-  //                 "name": undefined,
-  //                 "properties": [
-  //                   {
-  //                     "kind": "Interface",
-  //                     "name": "FunctionMetadata",
-  //                     "properties": [],
-  //                     "type": "FunctionMetadata",
-  //                   },
-  //                   {
-  //                     "kind": "Object",
-  //                     "name": undefined,
-  //                     "properties": [
-  //                       {
-  //                         "kind": "String",
-  //                         "name": "slug",
-  //                         "type": "string",
-  //                       },
-  //                       {
-  //                         "kind": "String",
-  //                         "name": "filePath",
-  //                         "type": "string",
-  //                       },
-  //                     ],
-  //                     "type": "{ slug: string; filePath: string; }",
-  //                   },
-  //                 ],
-  //                 "type": "FunctionMetadata & { slug: string; filePath: string; }",
-  //               },
-  //               {
-  //                 "kind": "Intersection",
-  //                 "name": undefined,
-  //                 "properties": [
-  //                   {
-  //                     "kind": "Interface",
-  //                     "name": "TypeMetadata",
-  //                     "properties": [],
-  //                     "type": "TypeMetadata",
-  //                   },
-  //                   {
-  //                     "kind": "Object",
-  //                     "name": undefined,
-  //                     "properties": [
-  //                       {
-  //                         "kind": "String",
-  //                         "name": "slug",
-  //                         "type": "string",
-  //                       },
-  //                       {
-  //                         "kind": "String",
-  //                         "name": "filePath",
-  //                         "type": "string",
-  //                       },
-  //                     ],
-  //                     "type": "{ slug: string; filePath: string; }",
-  //                   },
-  //                 ],
-  //                 "type": "TypeMetadata & { slug: string; filePath: string; }",
-  //               },
-  //             ],
-  //             "type": "ExportedType",
-  //           },
-  //         },
-  //       ],
-  //       "type": "ModuleData<Type>",
-  //     }
-  //   `)
-  // })
+    expect(types).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": "ModuleData",
+        "properties": [
+          {
+            "kind": "Array",
+            "name": "exportedTypes",
+            "type": {
+              "kind": "Union",
+              "name": "ExportedType",
+              "properties": [
+                {
+                  "kind": "Intersection",
+                  "name": undefined,
+                  "properties": [
+                    {
+                      "kind": "Reference",
+                      "type": "FunctionMetadata",
+                    },
+                    {
+                      "kind": "Object",
+                      "name": undefined,
+                      "properties": [
+                        {
+                          "kind": "String",
+                          "name": "slug",
+                          "type": "string",
+                        },
+                      ],
+                      "type": "{ slug: string; }",
+                    },
+                  ],
+                  "type": "FunctionMetadata & { slug: string; }",
+                },
+                {
+                  "kind": "Intersection",
+                  "name": undefined,
+                  "properties": [
+                    {
+                      "kind": "Reference",
+                      "type": "TypeMetadata",
+                    },
+                    {
+                      "kind": "Object",
+                      "name": undefined,
+                      "properties": [
+                        {
+                          "kind": "String",
+                          "name": "slug",
+                          "type": "string",
+                        },
+                      ],
+                      "type": "{ slug: string; }",
+                    },
+                  ],
+                  "type": "TypeMetadata & { slug: string; }",
+                },
+              ],
+              "type": "ExportedType",
+            },
+          },
+        ],
+        "type": "ModuleData<Type>",
+      }
+    `)
+  })
 })

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -293,32 +293,18 @@ describe('processProperties', () => {
           "name": "intersection",
           "properties": [
             {
-              "kind": "Object",
-              "name": undefined,
-              "properties": [
-                {
-                  "defaultValue": undefined,
-                  "isOptional": false,
-                  "kind": "String",
-                  "name": "a",
-                  "type": "string",
-                },
-              ],
-              "type": "{ a: string; }",
+              "defaultValue": undefined,
+              "isOptional": false,
+              "kind": "String",
+              "name": "a",
+              "type": "string",
             },
             {
-              "kind": "Object",
-              "name": undefined,
-              "properties": [
-                {
-                  "defaultValue": undefined,
-                  "isOptional": false,
-                  "kind": "Number",
-                  "name": "b",
-                  "type": "number",
-                },
-              ],
-              "type": "{ b: number; }",
+              "defaultValue": undefined,
+              "isOptional": false,
+              "kind": "Number",
+              "name": "b",
+              "type": "number",
             },
           ],
           "type": "{ a: string; } & { b: number; }",
@@ -341,39 +327,25 @@ describe('processProperties', () => {
               "type": "Promise<ExportedType>",
             },
             {
-              "kind": "Object",
-              "name": undefined,
-              "properties": [
-                {
-                  "defaultValue": undefined,
-                  "isOptional": false,
-                  "kind": "String",
-                  "name": "a",
-                  "type": "string",
-                },
-              ],
-              "type": "{ a: string; }",
+              "defaultValue": undefined,
+              "isOptional": false,
+              "kind": "String",
+              "name": "a",
+              "type": "string",
             },
             {
-              "kind": "Object",
-              "name": undefined,
-              "properties": [
+              "defaultValue": undefined,
+              "isOptional": false,
+              "kind": "Function",
+              "name": "b",
+              "signatures": [
                 {
-                  "defaultValue": undefined,
-                  "isOptional": false,
-                  "kind": "Function",
-                  "name": "b",
-                  "signatures": [
-                    {
-                      "parameters": [],
-                      "returnType": "void",
-                      "type": "() => void",
-                    },
-                  ],
+                  "parameters": [],
+                  "returnType": "void",
                   "type": "() => void",
                 },
               ],
-              "type": "{ b(): void; }",
+              "type": "() => void",
             },
           ],
           "type": "Promise<ExportedType> & { a: string; } & { b(): void; }",
@@ -474,18 +446,11 @@ describe('processProperties', () => {
             "name": "FillVariant",
             "properties": [
               {
-                "kind": "Object",
-                "name": undefined,
-                "properties": [
-                  {
-                    "defaultValue": undefined,
-                    "isOptional": false,
-                    "kind": "String",
-                    "name": "backgroundColor",
-                    "type": "string",
-                  },
-                ],
-                "type": "{ backgroundColor: string; }",
+                "defaultValue": undefined,
+                "isOptional": false,
+                "kind": "String",
+                "name": "backgroundColor",
+                "type": "string",
               },
               {
                 "kind": "Reference",
@@ -499,18 +464,11 @@ describe('processProperties', () => {
             "name": "OutlineVariant",
             "properties": [
               {
-                "kind": "Object",
-                "name": undefined,
-                "properties": [
-                  {
-                    "defaultValue": undefined,
-                    "isOptional": false,
-                    "kind": "String",
-                    "name": "borderColor",
-                    "type": "string",
-                  },
-                ],
-                "type": "{ borderColor: string; }",
+                "defaultValue": undefined,
+                "isOptional": false,
+                "kind": "String",
+                "name": "borderColor",
+                "type": "string",
               },
               {
                 "kind": "Reference",
@@ -1038,42 +996,28 @@ describe('processProperties', () => {
         "name": "TextProps",
         "properties": [
           {
-            "kind": "Object",
-            "name": undefined,
+            "defaultValue": undefined,
+            "isOptional": true,
+            "kind": "Union",
+            "name": "fontWeight",
             "properties": [
               {
-                "defaultValue": undefined,
-                "isOptional": true,
-                "kind": "Union",
-                "name": "fontWeight",
-                "properties": [
-                  {
-                    "kind": "String",
-                    "type": "string",
-                  },
-                  {
-                    "kind": "Number",
-                    "type": "number",
-                  },
-                ],
-                "type": "string | number",
+                "kind": "String",
+                "type": "string",
+              },
+              {
+                "kind": "Number",
+                "type": "number",
               },
             ],
-            "type": "{ fontWeight?: string | number; }",
+            "type": "string | number",
           },
           {
-            "kind": "Object",
-            "name": "DropDollarPrefix",
-            "properties": [
-              {
-                "defaultValue": undefined,
-                "isOptional": false,
-                "kind": "Reference",
-                "name": "color",
-                "type": "Color",
-              },
-            ],
-            "type": "DropDollarPrefix<StyledTextProps>",
+            "defaultValue": undefined,
+            "isOptional": false,
+            "kind": "Reference",
+            "name": "color",
+            "type": "Color",
           },
         ],
         "type": "TextProps",
@@ -1147,18 +1091,11 @@ describe('processProperties', () => {
                       "type": "FunctionMetadata",
                     },
                     {
-                      "kind": "Object",
-                      "name": undefined,
-                      "properties": [
-                        {
-                          "defaultValue": undefined,
-                          "isOptional": false,
-                          "kind": "String",
-                          "name": "slug",
-                          "type": "string",
-                        },
-                      ],
-                      "type": "{ slug: string; }",
+                      "defaultValue": undefined,
+                      "isOptional": false,
+                      "kind": "String",
+                      "name": "slug",
+                      "type": "string",
                     },
                   ],
                   "type": "FunctionMetadata & { slug: string; }",
@@ -1172,18 +1109,11 @@ describe('processProperties', () => {
                       "type": "TypeMetadata",
                     },
                     {
-                      "kind": "Object",
-                      "name": undefined,
-                      "properties": [
-                        {
-                          "defaultValue": undefined,
-                          "isOptional": false,
-                          "kind": "String",
-                          "name": "slug",
-                          "type": "string",
-                        },
-                      ],
-                      "type": "{ slug: string; }",
+                      "defaultValue": undefined,
+                      "isOptional": false,
+                      "kind": "String",
+                      "name": "slug",
+                      "type": "string",
                     },
                   ],
                   "type": "TypeMetadata & { slug: string; }",

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -18,7 +18,7 @@ describe('processProperties', () => {
     exportedTypes: Array<ExportedType>;
   };
 
-  export type FunctionType = (param1: string, param2: number) => Promise<ExportedType>;
+  export type FunctionType = (param1: string, param2?: number) => Promise<ExportedType>;
 
   const foo = async () => {
     return {
@@ -28,7 +28,7 @@ describe('processProperties', () => {
   }
 
   export type ComplexType = {
-    promiseObject: Promise<ExportedType>;
+    promiseObject?: Promise<ExportedType>;
     promiseFunction: Promise<(a: number, b: string) => void>;
     promiseVariable: ReturnType<typeof foo>;
     union: string | number;
@@ -51,6 +51,7 @@ describe('processProperties', () => {
         "name": "ModuleData",
         "properties": [
           {
+            "isOptional": false,
             "kind": "Function",
             "name": "method",
             "signatures": [
@@ -58,10 +59,12 @@ describe('processProperties', () => {
                 "parameters": [
                   {
                     "description": undefined,
+                    "isOptional": false,
                     "kind": "Object",
                     "name": "parameterValue",
                     "properties": [
                       {
+                        "isOptional": false,
                         "kind": "Number",
                         "name": "objectValue",
                         "type": "number",
@@ -77,6 +80,7 @@ describe('processProperties', () => {
             "type": "(parameterValue: {    objectValue: number;}) => Promise<number>",
           },
           {
+            "isOptional": false,
             "kind": "Array",
             "name": "exportedTypes",
             "type": {
@@ -104,6 +108,7 @@ describe('processProperties', () => {
               "type": "ExportedType",
             },
           ],
+          "isOptional": true,
           "kind": "Generic",
           "name": "promiseObject",
           "type": "Promise<ExportedType>",
@@ -118,12 +123,14 @@ describe('processProperties', () => {
                   "parameters": [
                     {
                       "description": undefined,
+                      "isOptional": false,
                       "kind": "Number",
                       "name": "a",
                       "type": "number",
                     },
                     {
                       "description": undefined,
+                      "isOptional": false,
                       "kind": "String",
                       "name": "b",
                       "type": "string",
@@ -136,6 +143,7 @@ describe('processProperties', () => {
               "type": "(a: number, b: string) => void",
             },
           ],
+          "isOptional": false,
           "kind": "Generic",
           "name": "promiseFunction",
           "type": "Promise<(a: number, b: string) => void>",
@@ -147,11 +155,13 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "isOptional": false,
                   "kind": "String",
                   "name": "slug",
                   "type": "string",
                 },
                 {
+                  "isOptional": false,
                   "kind": "String",
                   "name": "filePath",
                   "type": "string",
@@ -160,11 +170,13 @@ describe('processProperties', () => {
               "type": "{ slug: string; filePath: string; }",
             },
           ],
+          "isOptional": false,
           "kind": "Generic",
           "name": "promiseVariable",
           "type": "Promise<{ slug: string; filePath: string; }>",
         },
         {
+          "isOptional": false,
           "kind": "Union",
           "name": "union",
           "properties": [
@@ -180,6 +192,7 @@ describe('processProperties', () => {
           "type": "string | number",
         },
         {
+          "isOptional": false,
           "kind": "Union",
           "name": "complexUnion",
           "properties": [
@@ -195,6 +208,7 @@ describe('processProperties', () => {
                   "parameters": [
                     {
                       "description": undefined,
+                      "isOptional": false,
                       "kind": "String",
                       "name": "a",
                       "type": "string",
@@ -211,6 +225,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "isOptional": false,
                   "kind": "String",
                   "name": "a",
                   "type": "string",
@@ -223,11 +238,13 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "isOptional": false,
                   "kind": "Number",
                   "name": "b",
                   "type": "number",
                 },
                 {
+                  "isOptional": false,
                   "kind": "Array",
                   "name": "c",
                   "type": {
@@ -253,6 +270,7 @@ describe('processProperties', () => {
           "type": "string | ((a: string) => string | number) | { a: string; } | { b: number; c: (string | number)[]; }",
         },
         {
+          "isOptional": false,
           "kind": "Intersection",
           "name": "intersection",
           "properties": [
@@ -261,6 +279,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "isOptional": false,
                   "kind": "String",
                   "name": "a",
                   "type": "string",
@@ -273,6 +292,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "isOptional": false,
                   "kind": "Number",
                   "name": "b",
                   "type": "number",
@@ -284,6 +304,7 @@ describe('processProperties', () => {
           "type": "{ a: string; } & { b: number; }",
         },
         {
+          "isOptional": false,
           "kind": "Intersection",
           "name": "complexIntersection",
           "properties": [
@@ -303,6 +324,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "isOptional": false,
                   "kind": "String",
                   "name": "a",
                   "type": "string",
@@ -315,6 +337,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "isOptional": false,
                   "kind": "Function",
                   "name": "b",
                   "signatures": [
@@ -350,11 +373,13 @@ describe('processProperties', () => {
               "type": "string",
             },
           ],
+          "isOptional": false,
           "kind": "Tuple",
           "name": "tuple",
           "type": "[a: string, b: number, string]",
         },
         {
+          "isOptional": false,
           "kind": "Function",
           "name": "function",
           "signatures": [
@@ -362,19 +387,21 @@ describe('processProperties', () => {
               "parameters": [
                 {
                   "description": undefined,
+                  "isOptional": false,
                   "kind": "String",
                   "name": "param1",
                   "type": "string",
                 },
                 {
                   "description": undefined,
+                  "isOptional": true,
                   "kind": "Number",
                   "name": "param2",
                   "type": "number",
                 },
               ],
               "returnType": "Promise<ExportedType>",
-              "type": "(param1: string, param2: number) => Promise<ExportedType>",
+              "type": "(param1: string, param2?: number) => Promise<ExportedType>",
             },
           ],
           "type": "FunctionType",
@@ -424,6 +451,7 @@ describe('processProperties', () => {
                 "name": undefined,
                 "properties": [
                   {
+                    "isOptional": false,
                     "kind": "String",
                     "name": "backgroundColor",
                     "type": "string",
@@ -447,6 +475,7 @@ describe('processProperties', () => {
                 "name": undefined,
                 "properties": [
                   {
+                    "isOptional": false,
                     "kind": "String",
                     "name": "borderColor",
                     "type": "string",
@@ -507,6 +536,7 @@ describe('processProperties', () => {
         "properties": [
           {
             "description": "a string",
+            "isOptional": false,
             "kind": "String",
             "name": "str",
             "tags": undefined,
@@ -515,6 +545,7 @@ describe('processProperties', () => {
           {
             "description": "
       a number",
+            "isOptional": false,
             "kind": "Number",
             "name": "num",
             "tags": [
@@ -526,6 +557,7 @@ describe('processProperties', () => {
             "type": "number",
           },
           {
+            "isOptional": false,
             "kind": "Union",
             "name": "bool",
             "properties": [
@@ -541,6 +573,7 @@ describe('processProperties', () => {
             "type": "boolean",
           },
           {
+            "isOptional": false,
             "kind": "Array",
             "name": "arr",
             "type": {
@@ -559,6 +592,7 @@ describe('processProperties', () => {
                 "name": undefined,
                 "properties": [
                   {
+                    "isOptional": false,
                     "kind": "Number",
                     "name": "value",
                     "type": "number",
@@ -567,12 +601,14 @@ describe('processProperties', () => {
                 "type": "{ value: number; }",
               },
             ],
+            "isOptional": false,
             "kind": "Utility",
             "name": "obj",
             "type": "Record<string, { value: number; }>",
           },
           {
             "description": "Accepts a string",
+            "isOptional": false,
             "kind": "Function",
             "name": "func",
             "signatures": [
@@ -580,6 +616,7 @@ describe('processProperties', () => {
                 "parameters": [
                   {
                     "description": "a string parameter",
+                    "isOptional": false,
                     "kind": "String",
                     "name": "a",
                     "type": "string",
@@ -626,10 +663,12 @@ describe('processProperties', () => {
         "name": undefined,
         "properties": [
           {
+            "isOptional": false,
             "kind": "Object",
             "name": "e",
             "properties": [
               {
+                "isOptional": false,
                 "kind": "Number",
                 "name": "f",
                 "type": "number",
@@ -638,16 +677,19 @@ describe('processProperties', () => {
             "type": "{ f: number; }",
           },
           {
+            "isOptional": false,
             "kind": "String",
             "name": "g",
             "type": "string",
           },
           {
+            "isOptional": false,
             "kind": "Number",
             "name": "b",
             "type": "1",
           },
           {
+            "isOptional": false,
             "kind": "String",
             "name": "c",
             "type": ""string"",
@@ -678,11 +720,13 @@ describe('processProperties', () => {
         "name": "SelfReferencedType",
         "properties": [
           {
+            "isOptional": false,
             "kind": "String",
             "name": "id",
             "type": "string",
           },
           {
+            "isOptional": false,
             "kind": "Array",
             "name": "children",
             "type": {
@@ -724,6 +768,7 @@ describe('processProperties', () => {
         "name": "FileSystem",
         "properties": [
           {
+            "isOptional": false,
             "kind": "Reference",
             "name": "readFile",
             "type": "(path: string, callback: (err: Error, data: Buffer) => void) => void",
@@ -765,6 +810,7 @@ describe('processProperties', () => {
                 "name": "Foo",
                 "properties": [
                   {
+                    "isOptional": false,
                     "kind": "String",
                     "name": "bar",
                     "type": ""baz"",
@@ -773,6 +819,7 @@ describe('processProperties', () => {
                 "type": "Foo",
               },
             ],
+            "isOptional": false,
             "kind": "Generic",
             "name": "value",
             "type": "Promise<Foo>",
@@ -829,11 +876,13 @@ describe('processProperties', () => {
             "name": "UnwrapPromisesInMap",
             "properties": [
               {
+                "isOptional": false,
                 "kind": "Number",
                 "name": "a",
                 "type": "number",
               },
               {
+                "isOptional": false,
                 "kind": "String",
                 "name": "url",
                 "type": "string",
@@ -846,11 +895,13 @@ describe('processProperties', () => {
             "name": "UnwrapPromisesInMap",
             "properties": [
               {
+                "isOptional": false,
                 "kind": "String",
                 "name": "url",
                 "type": "string",
               },
               {
+                "isOptional": false,
                 "kind": "Number",
                 "name": "b",
                 "type": "number",
@@ -895,6 +946,7 @@ describe('processProperties', () => {
         "name": "TextProps",
         "properties": [
           {
+            "isOptional": false,
             "kind": "Reference",
             "name": "color",
             "type": "Color",
@@ -948,6 +1000,7 @@ describe('processProperties', () => {
             "name": undefined,
             "properties": [
               {
+                "isOptional": true,
                 "kind": "Union",
                 "name": "fontWeight",
                 "properties": [
@@ -970,6 +1023,7 @@ describe('processProperties', () => {
             "name": "DropDollarPrefix",
             "properties": [
               {
+                "isOptional": false,
                 "kind": "Reference",
                 "name": "color",
                 "type": "Color",
@@ -1032,6 +1086,7 @@ describe('processProperties', () => {
         "name": "ModuleData",
         "properties": [
           {
+            "isOptional": false,
             "kind": "Array",
             "name": "exportedTypes",
             "type": {
@@ -1051,6 +1106,7 @@ describe('processProperties', () => {
                       "name": undefined,
                       "properties": [
                         {
+                          "isOptional": false,
                           "kind": "String",
                           "name": "slug",
                           "type": "string",
@@ -1074,6 +1130,7 @@ describe('processProperties', () => {
                       "name": undefined,
                       "properties": [
                         {
+                          "isOptional": false,
                           "kind": "String",
                           "name": "slug",
                           "type": "string",
@@ -1125,6 +1182,7 @@ describe('processProperties', () => {
             "parameters": [
               {
                 "description": undefined,
+                "isOptional": false,
                 "kind": "Reference",
                 "name": "color",
                 "type": "Color",
@@ -1158,11 +1216,11 @@ describe('processProperties', () => {
         color: Color;
       }
       
-      export type Text = (props: TextProps) => void
+      export function Text(props?: TextProps) {}
       `,
       { overwrite: true }
     )
-    const typeAlias = sourceFile.getTypeAliasOrThrow('Text')
+    const typeAlias = sourceFile.getFunctionOrThrow('Text')
     const processedProperties = processType(typeAlias.getType())
 
     expect(processedProperties).toMatchInlineSnapshot(`
@@ -1174,10 +1232,12 @@ describe('processProperties', () => {
             "parameters": [
               {
                 "description": undefined,
+                "isOptional": true,
                 "kind": "Interface",
                 "name": "props",
                 "properties": [
                   {
+                    "isOptional": false,
                     "kind": "Reference",
                     "name": "color",
                     "type": "Color",
@@ -1187,10 +1247,10 @@ describe('processProperties', () => {
               },
             ],
             "returnType": "void",
-            "type": "(props: TextProps) => void",
+            "type": "(props?: TextProps) => void",
           },
         ],
-        "type": "Text",
+        "type": "(props?: TextProps) => void",
       }
     `)
   })
@@ -1231,6 +1291,7 @@ describe('processProperties', () => {
             "parameters": [
               {
                 "description": undefined,
+                "isOptional": false,
                 "kind": "Reference",
                 "name": "props",
                 "type": "TextProps",

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -57,6 +57,7 @@ describe('processProperties', () => {
             "name": "method",
             "signatures": [
               {
+                "modifier": undefined,
                 "parameters": [
                   {
                     "defaultValue": undefined,
@@ -125,6 +126,7 @@ describe('processProperties', () => {
               "name": undefined,
               "signatures": [
                 {
+                  "modifier": undefined,
                   "parameters": [
                     {
                       "defaultValue": undefined,
@@ -218,6 +220,7 @@ describe('processProperties', () => {
               "name": undefined,
               "signatures": [
                 {
+                  "modifier": undefined,
                   "parameters": [
                     {
                       "defaultValue": undefined,
@@ -340,6 +343,7 @@ describe('processProperties', () => {
               "name": "b",
               "signatures": [
                 {
+                  "modifier": undefined,
                   "parameters": [],
                   "returnType": "void",
                   "type": "() => void",
@@ -381,6 +385,7 @@ describe('processProperties', () => {
           "name": "function",
           "signatures": [
             {
+              "modifier": undefined,
               "parameters": [
                 {
                   "defaultValue": undefined,
@@ -510,7 +515,11 @@ describe('processProperties', () => {
           /** a string parameter */
           a: string,
         ) => void;
+
+        asyncFunc: typeof foo;
       }
+
+      async function foo() {}
     `
     )
     const typeAlias = sourceFile.getTypeAliasOrThrow('Primitives')
@@ -597,6 +606,7 @@ describe('processProperties', () => {
             "name": "func",
             "signatures": [
               {
+                "modifier": undefined,
                 "parameters": [
                   {
                     "defaultValue": undefined,
@@ -613,6 +623,21 @@ describe('processProperties', () => {
             ],
             "tags": undefined,
             "type": "(a: string) => void",
+          },
+          {
+            "defaultValue": undefined,
+            "isOptional": false,
+            "kind": "Function",
+            "name": "asyncFunc",
+            "signatures": [
+              {
+                "modifier": "async",
+                "parameters": [],
+                "returnType": "Promise<void>",
+                "type": "function foo(): Promise<void>",
+              },
+            ],
+            "type": "() => Promise<void>",
           },
         ],
         "type": "Primitives",
@@ -1156,6 +1181,7 @@ describe('processProperties', () => {
         "name": "Text",
         "signatures": [
           {
+            "modifier": undefined,
             "parameters": [
               {
                 "defaultValue": undefined,
@@ -1207,6 +1233,7 @@ describe('processProperties', () => {
         "name": "Text",
         "signatures": [
           {
+            "modifier": undefined,
             "parameters": [
               {
                 "defaultValue": undefined,
@@ -1268,6 +1295,7 @@ describe('processProperties', () => {
         "name": "Text",
         "signatures": [
           {
+            "modifier": undefined,
             "parameters": [
               {
                 "defaultValue": undefined,
@@ -1309,6 +1337,7 @@ describe('processProperties', () => {
         "name": "Text",
         "signatures": [
           {
+            "modifier": undefined,
             "parameters": [
               {
                 "defaultValue": {
@@ -1355,6 +1384,7 @@ describe('processProperties', () => {
         "name": "Text",
         "signatures": [
           {
+            "modifier": undefined,
             "parameters": [
               {
                 "defaultValue": {

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -1410,11 +1410,12 @@ describe('processProperties', () => {
       type TextProps = {
         style: {
           fontSize: number;
+          fontWeight: number;
           color?: string;
         };
       }
 
-      export function Text({ style: { fontSize, color } }: TextProps = { style: { fontSize: '1rem', color: 'blue' } }) {}
+      export function Text({ style: { fontSize, color } }: TextProps = { style: { fontWeight: 400, color: 'blue' } }) {}
       `
     )
     const typeAlias = sourceFile.getFunctionOrThrow('Text')
@@ -1431,7 +1432,7 @@ describe('processProperties', () => {
                 "defaultValue": {
                   "style": {
                     "color": "blue",
-                    "fontSize": "1rem",
+                    "fontWeight": 400,
                   },
                 },
                 "description": undefined,
@@ -1440,8 +1441,11 @@ describe('processProperties', () => {
                 "name": undefined,
                 "properties": [
                   {
-                    "defaultValue": undefined,
-                    "isOptional": false,
+                    "defaultValue": {
+                      "color": "blue",
+                      "fontWeight": 400,
+                    },
+                    "isOptional": true,
                     "kind": "Object",
                     "name": "style",
                     "properties": [
@@ -1453,14 +1457,21 @@ describe('processProperties', () => {
                         "type": "number",
                       },
                       {
-                        "defaultValue": undefined,
+                        "defaultValue": 400,
+                        "isOptional": true,
+                        "kind": "Number",
+                        "name": "fontWeight",
+                        "type": "number",
+                      },
+                      {
+                        "defaultValue": "blue",
                         "isOptional": true,
                         "kind": "String",
                         "name": "color",
                         "type": "string",
                       },
                     ],
-                    "type": "{ fontSize: number; color?: string; }",
+                    "type": "{ fontSize: number; fontWeight: number; color?: string; }",
                   },
                 ],
                 "type": "TextProps",

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -895,22 +895,8 @@ describe('processProperties', () => {
         "name": "TextProps",
         "properties": [
           {
-            "kind": "Union",
+            "kind": "Reference",
             "name": "color",
-            "properties": [
-              {
-                "kind": "String",
-                "type": ""red"",
-              },
-              {
-                "kind": "String",
-                "type": ""blue"",
-              },
-              {
-                "kind": "String",
-                "type": ""green"",
-              },
-            ],
             "type": "Color",
           },
         ],

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -558,18 +558,8 @@ describe('processProperties', () => {
           },
           {
             "isOptional": false,
-            "kind": "Union",
+            "kind": "Boolean",
             "name": "bool",
-            "properties": [
-              {
-                "kind": "Boolean",
-                "type": "false",
-              },
-              {
-                "kind": "Boolean",
-                "type": "true",
-              },
-            ],
             "type": "boolean",
           },
           {
@@ -1247,7 +1237,7 @@ describe('processProperties', () => {
               },
             ],
             "returnType": "void",
-            "type": "(props?: TextProps) => void",
+            "type": "function Text(props?: TextProps): void",
           },
         ],
         "type": "(props?: TextProps) => void",

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -1573,6 +1573,52 @@ describe('processProperties', () => {
     `)
   })
 
+  test('explicit undefined is a union', () => {
+    const project = new Project({
+      compilerOptions: {
+        strictNullChecks: true,
+      },
+    })
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      type TextProps = {
+        color: string | undefined;
+      }
+      `,
+      { overwrite: true }
+    )
+    const typeAlias = sourceFile.getTypeAliasOrThrow('TextProps')
+    const processedProperties = processType(typeAlias.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": "TextProps",
+        "properties": [
+          {
+            "defaultValue": undefined,
+            "isOptional": false,
+            "kind": "Union",
+            "name": "color",
+            "properties": [
+              {
+                "kind": "Primitive",
+                "type": "undefined",
+              },
+              {
+                "kind": "String",
+                "type": "string",
+              },
+            ],
+            "type": "string | undefined",
+          },
+        ],
+        "type": "TextProps",
+      }
+    `)
+  })
+
   test('complex library generic types', () => {
     const project = new Project({ tsConfigFilePath: 'tsconfig.json' })
     const sourceFile = project.createSourceFile(
@@ -1616,19 +1662,9 @@ describe('processProperties', () => {
                       {
                         "defaultValue": undefined,
                         "isOptional": true,
-                        "kind": "Union",
+                        "kind": "Reference",
                         "name": "theme",
-                        "properties": [
-                          {
-                            "kind": "Primitive",
-                            "type": "undefined",
-                          },
-                          {
-                            "kind": "Reference",
-                            "type": "DefaultTheme",
-                          },
-                        ],
-                        "type": "DefaultTheme | undefined",
+                        "type": "DefaultTheme",
                       },
                     ],
                     "type": "PolymorphicComponentProps<"web", Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, { fontSize: number; fontWeight?: number | undefined; }>, AsTarget, ForwardedAsTarget, AsTarget extends KnownTarget ? React.ComponentPropsWithRef<AsTarget> : {}, ForwardedAsTarget extends KnownTarget ? React.ComponentPropsWithRef<ForwardedAsTarget> : {}>",
@@ -1657,19 +1693,9 @@ describe('processProperties', () => {
                       {
                         "defaultValue": undefined,
                         "isOptional": true,
-                        "kind": "Union",
+                        "kind": "Number",
                         "name": "fontWeight",
-                        "properties": [
-                          {
-                            "kind": "Primitive",
-                            "type": "undefined",
-                          },
-                          {
-                            "kind": "Number",
-                            "type": "number",
-                          },
-                        ],
-                        "type": "number | undefined",
+                        "type": "number",
                       },
                     ],
                     "type": "Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, { fontSize: number; fontWeight?: number | undefined; }>",

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -80,20 +80,7 @@ describe('processProperties', () => {
             "kind": "Array",
             "name": "exportedTypes",
             "type": {
-              "kind": "Object",
-              "name": "ExportedType",
-              "properties": [
-                {
-                  "kind": "String",
-                  "name": "slug",
-                  "type": "string",
-                },
-                {
-                  "kind": "String",
-                  "name": "filePath",
-                  "type": "string",
-                },
-              ],
+              "kind": "Reference",
               "type": "ExportedType",
             },
           },
@@ -113,20 +100,7 @@ describe('processProperties', () => {
         {
           "arguments": [
             {
-              "kind": "Object",
-              "name": "ExportedType",
-              "properties": [
-                {
-                  "kind": "String",
-                  "name": "slug",
-                  "type": "string",
-                },
-                {
-                  "kind": "String",
-                  "name": "filePath",
-                  "type": "string",
-                },
-              ],
+              "kind": "Reference",
               "type": "ExportedType",
             },
           ],
@@ -316,20 +290,7 @@ describe('processProperties', () => {
             {
               "arguments": [
                 {
-                  "kind": "Object",
-                  "name": "ExportedType",
-                  "properties": [
-                    {
-                      "kind": "String",
-                      "name": "slug",
-                      "type": "string",
-                    },
-                    {
-                      "kind": "String",
-                      "name": "filePath",
-                      "type": "string",
-                    },
-                  ],
+                  "kind": "Reference",
                   "type": "ExportedType",
                 },
               ],
@@ -903,6 +864,61 @@ describe('processProperties', () => {
     `)
   })
 
+  test('creates reference for external types', () => {
+    const project = new Project()
+
+    project.createSourceFile(
+      './library/index.d.ts',
+      dedent`
+      export type Color = 'red' | 'blue' | 'green';
+      `
+    )
+
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      import { Color } from './library';
+
+      export type TextProps = {
+        color: Color
+      }
+      `,
+      { overwrite: true }
+    )
+    const types = processType(
+      sourceFile.getTypeAliasOrThrow('TextProps').getType()
+    )
+
+    expect(types).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": "TextProps",
+        "properties": [
+          {
+            "kind": "Union",
+            "name": "color",
+            "properties": [
+              {
+                "kind": "String",
+                "type": ""red"",
+              },
+              {
+                "kind": "String",
+                "type": ""blue"",
+              },
+              {
+                "kind": "String",
+                "type": ""green"",
+              },
+            ],
+            "type": "Color",
+          },
+        ],
+        "type": "TextProps",
+      }
+    `)
+  })
+
   test('creates reference for virtual types pointing to node modules', () => {
     const project = new Project()
 
@@ -981,7 +997,7 @@ describe('processProperties', () => {
     `)
   })
 
-  // test.only('simplifies complex generic types', () => {
+  // test('simplifies complex generic types', () => {
   //   const project = new Project()
 
   //   project.createSourceFile(
@@ -1098,36 +1114,6 @@ describe('processProperties', () => {
   //                   },
   //                 ],
   //                 "type": "TypeMetadata & { slug: string; filePath: string; }",
-  //               },
-  //               {
-  //                 "kind": "Intersection",
-  //                 "name": undefined,
-  //                 "properties": [
-  //                   {
-  //                     "kind": "Interface",
-  //                     "name": "PropertyMetadata",
-  //                     "properties": [],
-  //                     "type": "PropertyMetadata",
-  //                   },
-  //                   {
-  //                     "kind": "Object",
-  //                     "name": undefined,
-  //                     "properties": [
-  //                       {
-  //                         "kind": "String",
-  //                         "name": "slug",
-  //                         "type": "string",
-  //                       },
-  //                       {
-  //                         "kind": "String",
-  //                         "name": "filePath",
-  //                         "type": "string",
-  //                       },
-  //                     ],
-  //                     "type": "{ slug: string; filePath: string; }",
-  //                   },
-  //                 ],
-  //                 "type": "PropertyMetadata & { slug: string; filePath: string; }",
   //               },
   //             ],
   //             "type": "ExportedType",

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -163,15 +163,15 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
-                  "defaultValue": "foo",
-                  "isOptional": true,
+                  "defaultValue": undefined,
+                  "isOptional": false,
                   "kind": "String",
                   "name": "slug",
                   "type": "string",
                 },
                 {
-                  "defaultValue": "bar",
-                  "isOptional": true,
+                  "defaultValue": undefined,
+                  "isOptional": false,
                   "kind": "String",
                   "name": "filePath",
                   "type": "string",
@@ -690,16 +690,14 @@ describe('processProperties', () => {
         "name": undefined,
         "properties": [
           {
-            "defaultValue": {
-              "f": 1,
-            },
-            "isOptional": true,
+            "defaultValue": undefined,
+            "isOptional": false,
             "kind": "Object",
             "name": "e",
             "properties": [
               {
-                "defaultValue": 1,
-                "isOptional": true,
+                "defaultValue": undefined,
+                "isOptional": false,
                 "kind": "Number",
                 "name": "f",
                 "type": "number",
@@ -708,22 +706,22 @@ describe('processProperties', () => {
             "type": "{ f: number; }",
           },
           {
-            "defaultValue": "string",
-            "isOptional": true,
+            "defaultValue": undefined,
+            "isOptional": false,
             "kind": "String",
             "name": "g",
             "type": "string",
           },
           {
-            "defaultValue": 1,
-            "isOptional": true,
+            "defaultValue": undefined,
+            "isOptional": false,
             "kind": "Number",
             "name": "b",
             "type": "1",
           },
           {
-            "defaultValue": "string",
-            "isOptional": true,
+            "defaultValue": undefined,
+            "isOptional": false,
             "kind": "String",
             "name": "c",
             "type": ""string"",

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -1483,4 +1483,77 @@ describe('processProperties', () => {
       }
     `)
   })
+
+  test('conditional generic', () => {
+    const project = new Project()
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      type ModuleData<Type extends { frontMatter: Record<string, any> }> = 'frontMatter' extends keyof Type
+          ? Type
+          : { frontMatter: Record<string, any> }
+      `,
+      { overwrite: true }
+    )
+    const typeAlias = sourceFile.getTypeAliasOrThrow('ModuleData')
+    const types = processType(typeAlias.getType(), typeAlias)
+
+    expect(types).toMatchInlineSnapshot(`
+      {
+        "kind": "Union",
+        "name": undefined,
+        "properties": [
+          {
+            "kind": "Object",
+            "name": undefined,
+            "properties": [
+              {
+                "arguments": [
+                  {
+                    "kind": "String",
+                    "type": "string",
+                  },
+                  {
+                    "kind": "Primitive",
+                    "type": "any",
+                  },
+                ],
+                "defaultValue": undefined,
+                "isOptional": false,
+                "kind": "Utility",
+                "name": "frontMatter",
+                "type": "Record<string, any>",
+              },
+            ],
+            "type": "{ frontMatter: Record<string, any>; }",
+          },
+          {
+            "kind": "Object",
+            "name": undefined,
+            "properties": [
+              {
+                "arguments": [
+                  {
+                    "kind": "String",
+                    "type": "string",
+                  },
+                  {
+                    "kind": "Primitive",
+                    "type": "any",
+                  },
+                ],
+                "defaultValue": undefined,
+                "isOptional": false,
+                "kind": "Utility",
+                "name": "frontMatter",
+                "type": "Record<string, any>",
+              },
+            ],
+            "type": "{ frontMatter: Record<string, any>; }",
+          },
+        ],
+        "type": "{ frontMatter: Record<string, any>; } | { frontMatter: Record<string, any>; }",
+      }
+    `)
+  })
 })

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -1576,4 +1576,122 @@ describe('processProperties', () => {
       }
     `)
   })
+
+  test('complex library generic types', () => {
+    const project = new Project({ tsConfigFilePath: 'tsconfig.json' })
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      import styled from 'styled-components'
+      export const Text = styled.span<{ fontSize: number; fontWeight?: number }>({})
+      `
+    )
+    const variableDeclaration = sourceFile.getVariableDeclarationOrThrow('Text')
+    const processedType = processType(
+      variableDeclaration.getType(),
+      variableDeclaration,
+      (symbolMetadata) => {
+        if (symbolMetadata.name === 'theme') {
+          return true
+        }
+        return !symbolMetadata.isInNodeModules
+      }
+    )
+
+    expect(processedType).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": undefined,
+        "properties": [
+          {
+            "kind": "Function",
+            "name": "IStyledComponentBase",
+            "signatures": [
+              {
+                "modifier": undefined,
+                "parameters": [
+                  {
+                    "defaultValue": undefined,
+                    "description": undefined,
+                    "isOptional": false,
+                    "kind": "Object",
+                    "name": "props",
+                    "properties": [
+                      {
+                        "defaultValue": undefined,
+                        "isOptional": true,
+                        "kind": "Union",
+                        "name": "theme",
+                        "properties": [
+                          {
+                            "kind": "Primitive",
+                            "type": "undefined",
+                          },
+                          {
+                            "kind": "Reference",
+                            "type": "DefaultTheme",
+                          },
+                        ],
+                        "type": "DefaultTheme | undefined",
+                      },
+                    ],
+                    "type": "PolymorphicComponentProps<"web", Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, { fontSize: number; fontWeight?: number | undefined; }>, AsTarget, ForwardedAsTarget, AsTarget extends KnownTarget ? React.ComponentPropsWithRef<AsTarget> : {}, ForwardedAsTarget extends KnownTarget ? React.ComponentPropsWithRef<ForwardedAsTarget> : {}>",
+                  },
+                ],
+                "returnType": "Element",
+                "type": "<AsTarget, ForwardedAsTarget>(props: PolymorphicComponentProps<"web", Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, { fontSize: number; fontWeight?: number | undefined; }>, AsTarget, ForwardedAsTarget, AsTarget extends KnownTarget ? React.ComponentPropsWithRef<AsTarget> : {}, ForwardedAsTarget extends KnownTarget ? React.ComponentPropsWithRef<ForwardedAsTarget> : {}>) => Element",
+              },
+              {
+                "modifier": undefined,
+                "parameters": [
+                  {
+                    "defaultValue": undefined,
+                    "description": undefined,
+                    "isOptional": false,
+                    "kind": "Object",
+                    "name": "props",
+                    "properties": [
+                      {
+                        "defaultValue": undefined,
+                        "isOptional": false,
+                        "kind": "Number",
+                        "name": "fontSize",
+                        "type": "number",
+                      },
+                      {
+                        "defaultValue": undefined,
+                        "isOptional": true,
+                        "kind": "Union",
+                        "name": "fontWeight",
+                        "properties": [
+                          {
+                            "kind": "Primitive",
+                            "type": "undefined",
+                          },
+                          {
+                            "kind": "Number",
+                            "type": "number",
+                          },
+                        ],
+                        "type": "number | undefined",
+                      },
+                    ],
+                    "type": "Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, { fontSize: number; fontWeight?: number | undefined; }>",
+                  },
+                ],
+                "returnType": "ReactNode",
+                "type": "(props: Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, { fontSize: number; fontWeight?: number | undefined; }>) => ReactNode",
+              },
+            ],
+            "type": "IStyledComponentBase<"web", Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, { fontSize: number; fontWeight?: number | undefined; }>>",
+          },
+          {
+            "kind": "String",
+            "type": "string",
+          },
+        ],
+        "type": "IStyledComponentBase<"web", Substitute<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, { fontSize: number; fontWeight?: number | undefined; }>> & string",
+      }
+    `)
+  })
 })

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -51,6 +51,7 @@ describe('processProperties', () => {
         "name": "ModuleData",
         "properties": [
           {
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Function",
             "name": "method",
@@ -58,12 +59,14 @@ describe('processProperties', () => {
               {
                 "parameters": [
                   {
+                    "defaultValue": undefined,
                     "description": undefined,
                     "isOptional": false,
                     "kind": "Object",
                     "name": "parameterValue",
                     "properties": [
                       {
+                        "defaultValue": undefined,
                         "isOptional": false,
                         "kind": "Number",
                         "name": "objectValue",
@@ -80,6 +83,7 @@ describe('processProperties', () => {
             "type": "(parameterValue: {    objectValue: number;}) => Promise<number>",
           },
           {
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Array",
             "name": "exportedTypes",
@@ -108,6 +112,7 @@ describe('processProperties', () => {
               "type": "ExportedType",
             },
           ],
+          "defaultValue": undefined,
           "isOptional": true,
           "kind": "Generic",
           "name": "promiseObject",
@@ -122,6 +127,7 @@ describe('processProperties', () => {
                 {
                   "parameters": [
                     {
+                      "defaultValue": undefined,
                       "description": undefined,
                       "isOptional": false,
                       "kind": "Number",
@@ -129,6 +135,7 @@ describe('processProperties', () => {
                       "type": "number",
                     },
                     {
+                      "defaultValue": undefined,
                       "description": undefined,
                       "isOptional": false,
                       "kind": "String",
@@ -143,6 +150,7 @@ describe('processProperties', () => {
               "type": "(a: number, b: string) => void",
             },
           ],
+          "defaultValue": undefined,
           "isOptional": false,
           "kind": "Generic",
           "name": "promiseFunction",
@@ -155,13 +163,15 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
-                  "isOptional": false,
+                  "defaultValue": "foo",
+                  "isOptional": true,
                   "kind": "String",
                   "name": "slug",
                   "type": "string",
                 },
                 {
-                  "isOptional": false,
+                  "defaultValue": "bar",
+                  "isOptional": true,
                   "kind": "String",
                   "name": "filePath",
                   "type": "string",
@@ -170,12 +180,14 @@ describe('processProperties', () => {
               "type": "{ slug: string; filePath: string; }",
             },
           ],
+          "defaultValue": undefined,
           "isOptional": false,
           "kind": "Generic",
           "name": "promiseVariable",
           "type": "Promise<{ slug: string; filePath: string; }>",
         },
         {
+          "defaultValue": undefined,
           "isOptional": false,
           "kind": "Union",
           "name": "union",
@@ -192,6 +204,7 @@ describe('processProperties', () => {
           "type": "string | number",
         },
         {
+          "defaultValue": undefined,
           "isOptional": false,
           "kind": "Union",
           "name": "complexUnion",
@@ -207,6 +220,7 @@ describe('processProperties', () => {
                 {
                   "parameters": [
                     {
+                      "defaultValue": undefined,
                       "description": undefined,
                       "isOptional": false,
                       "kind": "String",
@@ -225,6 +239,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "defaultValue": undefined,
                   "isOptional": false,
                   "kind": "String",
                   "name": "a",
@@ -238,12 +253,14 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "defaultValue": undefined,
                   "isOptional": false,
                   "kind": "Number",
                   "name": "b",
                   "type": "number",
                 },
                 {
+                  "defaultValue": undefined,
                   "isOptional": false,
                   "kind": "Array",
                   "name": "c",
@@ -270,6 +287,7 @@ describe('processProperties', () => {
           "type": "string | ((a: string) => string | number) | { a: string; } | { b: number; c: (string | number)[]; }",
         },
         {
+          "defaultValue": undefined,
           "isOptional": false,
           "kind": "Object",
           "name": "intersection",
@@ -279,6 +297,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "defaultValue": undefined,
                   "isOptional": false,
                   "kind": "String",
                   "name": "a",
@@ -292,6 +311,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "defaultValue": undefined,
                   "isOptional": false,
                   "kind": "Number",
                   "name": "b",
@@ -304,6 +324,7 @@ describe('processProperties', () => {
           "type": "{ a: string; } & { b: number; }",
         },
         {
+          "defaultValue": undefined,
           "isOptional": false,
           "kind": "Object",
           "name": "complexIntersection",
@@ -324,6 +345,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "defaultValue": undefined,
                   "isOptional": false,
                   "kind": "String",
                   "name": "a",
@@ -337,6 +359,7 @@ describe('processProperties', () => {
               "name": undefined,
               "properties": [
                 {
+                  "defaultValue": undefined,
                   "isOptional": false,
                   "kind": "Function",
                   "name": "b",
@@ -356,6 +379,7 @@ describe('processProperties', () => {
           "type": "Promise<ExportedType> & { a: string; } & { b(): void; }",
         },
         {
+          "defaultValue": undefined,
           "elements": [
             {
               "kind": "String",
@@ -379,6 +403,7 @@ describe('processProperties', () => {
           "type": "[a: string, b: number, string]",
         },
         {
+          "defaultValue": undefined,
           "isOptional": false,
           "kind": "Function",
           "name": "function",
@@ -386,6 +411,7 @@ describe('processProperties', () => {
             {
               "parameters": [
                 {
+                  "defaultValue": undefined,
                   "description": undefined,
                   "isOptional": false,
                   "kind": "String",
@@ -393,6 +419,7 @@ describe('processProperties', () => {
                   "type": "string",
                 },
                 {
+                  "defaultValue": undefined,
                   "description": undefined,
                   "isOptional": true,
                   "kind": "Number",
@@ -451,6 +478,7 @@ describe('processProperties', () => {
                 "name": undefined,
                 "properties": [
                   {
+                    "defaultValue": undefined,
                     "isOptional": false,
                     "kind": "String",
                     "name": "backgroundColor",
@@ -475,6 +503,7 @@ describe('processProperties', () => {
                 "name": undefined,
                 "properties": [
                   {
+                    "defaultValue": undefined,
                     "isOptional": false,
                     "kind": "String",
                     "name": "borderColor",
@@ -535,6 +564,7 @@ describe('processProperties', () => {
         "name": "Primitives",
         "properties": [
           {
+            "defaultValue": undefined,
             "description": "a string",
             "isOptional": false,
             "kind": "String",
@@ -543,6 +573,7 @@ describe('processProperties', () => {
             "type": "string",
           },
           {
+            "defaultValue": undefined,
             "description": "
       a number",
             "isOptional": false,
@@ -557,12 +588,14 @@ describe('processProperties', () => {
             "type": "number",
           },
           {
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Boolean",
             "name": "bool",
             "type": "boolean",
           },
           {
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Array",
             "name": "arr",
@@ -582,6 +615,7 @@ describe('processProperties', () => {
                 "name": undefined,
                 "properties": [
                   {
+                    "defaultValue": undefined,
                     "isOptional": false,
                     "kind": "Number",
                     "name": "value",
@@ -591,12 +625,14 @@ describe('processProperties', () => {
                 "type": "{ value: number; }",
               },
             ],
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Utility",
             "name": "obj",
             "type": "Record<string, { value: number; }>",
           },
           {
+            "defaultValue": undefined,
             "description": "Accepts a string",
             "isOptional": false,
             "kind": "Function",
@@ -605,6 +641,7 @@ describe('processProperties', () => {
               {
                 "parameters": [
                   {
+                    "defaultValue": undefined,
                     "description": "a string parameter",
                     "isOptional": false,
                     "kind": "String",
@@ -653,12 +690,16 @@ describe('processProperties', () => {
         "name": undefined,
         "properties": [
           {
-            "isOptional": false,
+            "defaultValue": {
+              "f": 1,
+            },
+            "isOptional": true,
             "kind": "Object",
             "name": "e",
             "properties": [
               {
-                "isOptional": false,
+                "defaultValue": 1,
+                "isOptional": true,
                 "kind": "Number",
                 "name": "f",
                 "type": "number",
@@ -667,19 +708,22 @@ describe('processProperties', () => {
             "type": "{ f: number; }",
           },
           {
-            "isOptional": false,
+            "defaultValue": "string",
+            "isOptional": true,
             "kind": "String",
             "name": "g",
             "type": "string",
           },
           {
-            "isOptional": false,
+            "defaultValue": 1,
+            "isOptional": true,
             "kind": "Number",
             "name": "b",
             "type": "1",
           },
           {
-            "isOptional": false,
+            "defaultValue": "string",
+            "isOptional": true,
             "kind": "String",
             "name": "c",
             "type": ""string"",
@@ -710,12 +754,14 @@ describe('processProperties', () => {
         "name": "SelfReferencedType",
         "properties": [
           {
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "String",
             "name": "id",
             "type": "string",
           },
           {
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Array",
             "name": "children",
@@ -758,6 +804,7 @@ describe('processProperties', () => {
         "name": "FileSystem",
         "properties": [
           {
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Reference",
             "name": "readFile",
@@ -800,6 +847,7 @@ describe('processProperties', () => {
                 "name": "Foo",
                 "properties": [
                   {
+                    "defaultValue": undefined,
                     "isOptional": false,
                     "kind": "String",
                     "name": "bar",
@@ -809,6 +857,7 @@ describe('processProperties', () => {
                 "type": "Foo",
               },
             ],
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Generic",
             "name": "value",
@@ -866,12 +915,14 @@ describe('processProperties', () => {
             "name": "UnwrapPromisesInMap",
             "properties": [
               {
+                "defaultValue": undefined,
                 "isOptional": false,
                 "kind": "Number",
                 "name": "a",
                 "type": "number",
               },
               {
+                "defaultValue": undefined,
                 "isOptional": false,
                 "kind": "String",
                 "name": "url",
@@ -885,12 +936,14 @@ describe('processProperties', () => {
             "name": "UnwrapPromisesInMap",
             "properties": [
               {
+                "defaultValue": undefined,
                 "isOptional": false,
                 "kind": "String",
                 "name": "url",
                 "type": "string",
               },
               {
+                "defaultValue": undefined,
                 "isOptional": false,
                 "kind": "Number",
                 "name": "b",
@@ -936,6 +989,7 @@ describe('processProperties', () => {
         "name": "TextProps",
         "properties": [
           {
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Reference",
             "name": "color",
@@ -990,6 +1044,7 @@ describe('processProperties', () => {
             "name": undefined,
             "properties": [
               {
+                "defaultValue": undefined,
                 "isOptional": true,
                 "kind": "Union",
                 "name": "fontWeight",
@@ -1013,6 +1068,7 @@ describe('processProperties', () => {
             "name": "DropDollarPrefix",
             "properties": [
               {
+                "defaultValue": undefined,
                 "isOptional": false,
                 "kind": "Reference",
                 "name": "color",
@@ -1076,6 +1132,7 @@ describe('processProperties', () => {
         "name": "ModuleData",
         "properties": [
           {
+            "defaultValue": undefined,
             "isOptional": false,
             "kind": "Array",
             "name": "exportedTypes",
@@ -1096,6 +1153,7 @@ describe('processProperties', () => {
                       "name": undefined,
                       "properties": [
                         {
+                          "defaultValue": undefined,
                           "isOptional": false,
                           "kind": "String",
                           "name": "slug",
@@ -1120,6 +1178,7 @@ describe('processProperties', () => {
                       "name": undefined,
                       "properties": [
                         {
+                          "defaultValue": undefined,
                           "isOptional": false,
                           "kind": "String",
                           "name": "slug",
@@ -1171,6 +1230,7 @@ describe('processProperties', () => {
           {
             "parameters": [
               {
+                "defaultValue": undefined,
                 "description": undefined,
                 "isOptional": false,
                 "kind": "Reference",
@@ -1221,12 +1281,14 @@ describe('processProperties', () => {
           {
             "parameters": [
               {
+                "defaultValue": undefined,
                 "description": undefined,
                 "isOptional": true,
                 "kind": "Object",
                 "name": "props",
                 "properties": [
                   {
+                    "defaultValue": undefined,
                     "isOptional": false,
                     "kind": "Reference",
                     "name": "color",
@@ -1280,6 +1342,7 @@ describe('processProperties', () => {
           {
             "parameters": [
               {
+                "defaultValue": undefined,
                 "description": undefined,
                 "isOptional": false,
                 "kind": "Reference",
@@ -1292,6 +1355,122 @@ describe('processProperties', () => {
           },
         ],
         "type": "Text",
+      }
+    `)
+  })
+
+  test('default parameter values', () => {
+    const project = new Project()
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      export type TextProps = {
+        color: string;
+        fontSize?: number;
+      }
+
+      export function Text(props: TextProps = { color: 'red' }) {}
+      `
+    )
+    const typeAlias = sourceFile.getFunctionOrThrow('Text')
+    const processedProperties = processType(typeAlias.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Function",
+        "name": "Text",
+        "signatures": [
+          {
+            "parameters": [
+              {
+                "defaultValue": {
+                  "color": "red",
+                },
+                "description": undefined,
+                "isOptional": false,
+                "kind": "Reference",
+                "name": "props",
+                "type": "TextProps",
+              },
+            ],
+            "returnType": "void",
+            "type": "function Text(props: TextProps): void",
+          },
+        ],
+        "type": "(props?: TextProps) => void",
+      }
+    `)
+  })
+
+  test('default object values', () => {
+    const project = new Project()
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      type TextProps = {
+        style: {
+          fontSize: number;
+          color?: string;
+        };
+      }
+
+      export function Text({ style: { fontSize, color } }: TextProps = { style: { fontSize: '1rem', color: 'blue' } }) {}
+      `
+    )
+    const typeAlias = sourceFile.getFunctionOrThrow('Text')
+    const processedProperties = processType(typeAlias.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Function",
+        "name": "Text",
+        "signatures": [
+          {
+            "parameters": [
+              {
+                "defaultValue": {
+                  "style": {
+                    "color": "blue",
+                    "fontSize": "1rem",
+                  },
+                },
+                "description": undefined,
+                "isOptional": false,
+                "kind": "Object",
+                "name": undefined,
+                "properties": [
+                  {
+                    "defaultValue": undefined,
+                    "isOptional": false,
+                    "kind": "Object",
+                    "name": "style",
+                    "properties": [
+                      {
+                        "defaultValue": undefined,
+                        "isOptional": false,
+                        "kind": "Number",
+                        "name": "fontSize",
+                        "type": "number",
+                      },
+                      {
+                        "defaultValue": undefined,
+                        "isOptional": true,
+                        "kind": "String",
+                        "name": "color",
+                        "type": "string",
+                      },
+                    ],
+                    "type": "{ fontSize: number; color?: string; }",
+                  },
+                ],
+                "type": "TextProps",
+              },
+            ],
+            "returnType": "void",
+            "type": "function Text(TextProps): void",
+          },
+        ],
+        "type": "({ style: { fontSize, color } }?: TextProps) => void",
       }
     `)
   })

--- a/packages/utils/src/types/processType.test.ts
+++ b/packages/utils/src/types/processType.test.ts
@@ -1,5 +1,6 @@
 import { Project } from 'ts-morph'
 import { processTypeProperties, processType } from './processType'
+import dedent from 'dedent'
 
 describe('processProperties', () => {
   const project = new Project()
@@ -73,7 +74,7 @@ describe('processProperties', () => {
                 "type": "(parameterValue: { objectValue: number; }) => Promise<number>",
               },
             ],
-            "type": "(parameterValue: { objectValue: number; }) => Promise<number>",
+            "type": "(parameterValue: {    objectValue: number;}) => Promise<number>",
           },
           {
             "kind": "Array",
@@ -110,75 +111,84 @@ describe('processProperties', () => {
     expect(processedProperties).toMatchInlineSnapshot(`
       [
         {
-          "kind": "Promise",
+          "arguments": [
+            {
+              "kind": "Object",
+              "name": "ExportedType",
+              "properties": [
+                {
+                  "kind": "String",
+                  "name": "slug",
+                  "type": "string",
+                },
+                {
+                  "kind": "String",
+                  "name": "filePath",
+                  "type": "string",
+                },
+              ],
+              "type": "ExportedType",
+            },
+          ],
+          "kind": "Generic",
           "name": "promiseObject",
-          "type": {
-            "kind": "Object",
-            "name": "ExportedType",
-            "properties": [
-              {
-                "kind": "String",
-                "name": "slug",
-                "type": "string",
-              },
-              {
-                "kind": "String",
-                "name": "filePath",
-                "type": "string",
-              },
-            ],
-            "type": "ExportedType",
-          },
+          "type": "Promise<ExportedType>",
         },
         {
-          "kind": "Promise",
+          "arguments": [
+            {
+              "kind": "Function",
+              "name": undefined,
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "description": undefined,
+                      "kind": "Number",
+                      "name": "a",
+                      "type": "number",
+                    },
+                    {
+                      "description": undefined,
+                      "kind": "String",
+                      "name": "b",
+                      "type": "string",
+                    },
+                  ],
+                  "returnType": "void",
+                  "type": "(a: number, b: string) => void",
+                },
+              ],
+              "type": "(a: number, b: string) => void",
+            },
+          ],
+          "kind": "Generic",
           "name": "promiseFunction",
-          "type": {
-            "kind": "Function",
-            "name": undefined,
-            "signatures": [
-              {
-                "parameters": [
-                  {
-                    "description": undefined,
-                    "kind": "Number",
-                    "name": "a",
-                    "type": "number",
-                  },
-                  {
-                    "description": undefined,
-                    "kind": "String",
-                    "name": "b",
-                    "type": "string",
-                  },
-                ],
-                "returnType": "void",
-                "type": "(a: number, b: string) => void",
-              },
-            ],
-            "type": "(a: number, b: string) => void",
-          },
+          "type": "Promise<(a: number, b: string) => void>",
         },
         {
-          "kind": "Promise",
+          "arguments": [
+            {
+              "kind": "Object",
+              "name": undefined,
+              "properties": [
+                {
+                  "kind": "String",
+                  "name": "slug",
+                  "type": "string",
+                },
+                {
+                  "kind": "String",
+                  "name": "filePath",
+                  "type": "string",
+                },
+              ],
+              "type": "{ slug: string; filePath: string; }",
+            },
+          ],
+          "kind": "Generic",
           "name": "promiseVariable",
-          "type": {
-            "kind": "Object",
-            "name": undefined,
-            "properties": [
-              {
-                "kind": "String",
-                "name": "slug",
-                "type": "string",
-              },
-              {
-                "kind": "String",
-                "name": "filePath",
-                "type": "string",
-              },
-            ],
-            "type": "{ slug: string; filePath: string; }",
-          },
+          "type": "Promise<{ slug: string; filePath: string; }>",
         },
         {
           "kind": "Union",
@@ -304,24 +314,28 @@ describe('processProperties', () => {
           "name": "complexIntersection",
           "properties": [
             {
-              "kind": "Promise",
-              "type": {
-                "kind": "Object",
-                "name": "ExportedType",
-                "properties": [
-                  {
-                    "kind": "String",
-                    "name": "slug",
-                    "type": "string",
-                  },
-                  {
-                    "kind": "String",
-                    "name": "filePath",
-                    "type": "string",
-                  },
-                ],
-                "type": "ExportedType",
-              },
+              "arguments": [
+                {
+                  "kind": "Object",
+                  "name": "ExportedType",
+                  "properties": [
+                    {
+                      "kind": "String",
+                      "name": "slug",
+                      "type": "string",
+                    },
+                    {
+                      "kind": "String",
+                      "name": "filePath",
+                      "type": "string",
+                    },
+                  ],
+                  "type": "ExportedType",
+                },
+              ],
+              "kind": "Generic",
+              "name": "Promise",
+              "type": "Promise<ExportedType>",
             },
             {
               "kind": "Object",
@@ -457,15 +471,7 @@ describe('processProperties', () => {
                 "type": "{ backgroundColor: string; }",
               },
               {
-                "kind": "Object",
-                "name": "BaseVariant",
-                "properties": [
-                  {
-                    "kind": "String",
-                    "name": "color",
-                    "type": "string",
-                  },
-                ],
+                "kind": "Reference",
                 "type": "BaseVariant",
               },
             ],
@@ -488,15 +494,7 @@ describe('processProperties', () => {
                 "type": "{ borderColor: string; }",
               },
               {
-                "kind": "Object",
-                "name": "BaseVariant",
-                "properties": [
-                  {
-                    "kind": "String",
-                    "name": "color",
-                    "type": "string",
-                  },
-                ],
+                "kind": "Reference",
                 "type": "BaseVariant",
               },
             ],
@@ -516,20 +514,25 @@ describe('processProperties', () => {
       type Primitives = {
         /** a string */
         str: string;
+        
         /**
          * a number
          * @internal
          */
         num: number;
-        /* no js doc */
+        
         bool: boolean;
+        
+        arr: string[];
+        
+        /* non js doc */
+        obj: Record<string, any>;
+        
         /** Accepts a string */
         func: (
           /** a string parameter */
           a: string,
         ) => void;
-        arr: string[];
-        obj: Record<string, any>;
       }
     `
     )
@@ -567,6 +570,20 @@ describe('processProperties', () => {
             "type": "boolean",
           },
           {
+            "kind": "Array",
+            "name": "arr",
+            "type": {
+              "kind": "String",
+              "type": "string",
+            },
+          },
+          {
+            "kind": "Object",
+            "name": "obj",
+            "properties": [],
+            "type": "Record<string, any>",
+          },
+          {
             "description": "Accepts a string",
             "kind": "Function",
             "name": "func",
@@ -586,20 +603,6 @@ describe('processProperties', () => {
             ],
             "tags": undefined,
             "type": "(a: string) => void",
-          },
-          {
-            "kind": "Array",
-            "name": "arr",
-            "type": {
-              "kind": "String",
-              "type": "string",
-            },
-          },
-          {
-            "kind": "Object",
-            "name": "obj",
-            "properties": [],
-            "type": "Record<string, any>",
           },
         ],
         "type": "Primitives",
@@ -652,12 +655,12 @@ describe('processProperties', () => {
             "type": "string",
           },
           {
-            "kind": "Literal",
+            "kind": "Number",
             "name": "b",
             "type": "1",
           },
           {
-            "kind": "Literal",
+            "kind": "String",
             "name": "c",
             "type": ""string"",
           },
@@ -701,6 +704,216 @@ describe('processProperties', () => {
           },
         ],
         "type": "SelfReferencedType",
+      }
+    `)
+  })
+
+  test('references property signature types located in node_modules', () => {
+    const project = new Project()
+
+    project.createSourceFile(
+      'node_modules/@types/library/index.d.ts',
+      dedent`
+      export function readFile(path: string, callback: (err: Error | null, data: Buffer) => void): void;
+      `
+    )
+
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      `
+      import { readFile } from 'library';
+
+      type FileSystem = { readFile: typeof readFile };
+      `
+    )
+
+    const typeAlias = sourceFile.getTypeAliasOrThrow('FileSystem')
+    const processedProperties = processType(typeAlias.getType(), typeAlias)
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": "FileSystem",
+        "properties": [
+          {
+            "kind": "Function",
+            "name": "readFile",
+            "signatures": [
+              {
+                "parameters": [
+                  {
+                    "description": undefined,
+                    "kind": "String",
+                    "name": "path",
+                    "type": "string",
+                  },
+                  {
+                    "description": undefined,
+                    "kind": "Function",
+                    "name": "callback",
+                    "signatures": [
+                      {
+                        "parameters": [
+                          {
+                            "description": undefined,
+                            "kind": "Interface",
+                            "name": "err",
+                            "properties": [],
+                            "type": "Error",
+                          },
+                          {
+                            "description": undefined,
+                            "kind": "Interface",
+                            "name": "data",
+                            "properties": [],
+                            "type": "Buffer",
+                          },
+                        ],
+                        "returnType": "void",
+                        "type": "(err: Error, data: Buffer) => void",
+                      },
+                    ],
+                    "type": "(err: Error, data: Buffer) => void",
+                  },
+                ],
+                "returnType": "void",
+                "type": "(path: string, callback: (err: Error, data: Buffer) => void) => void",
+              },
+            ],
+            "type": "(path: string, callback: (err: Error, data: Buffer) => void) => void",
+          },
+        ],
+        "type": "FileSystem",
+      }
+    `)
+  })
+
+  test('avoids analyzing prototype properties and methods', () => {
+    const project = new Project()
+
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      type Foo = {
+        bar: 'baz'
+      }
+      
+      type AsyncString = {
+        value: Promise<Foo>
+      }
+      `
+    )
+
+    const typeAlias = sourceFile.getTypeAliasOrThrow('AsyncString')
+    const processedProperties = processType(typeAlias.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Object",
+        "name": "AsyncString",
+        "properties": [
+          {
+            "arguments": [
+              {
+                "kind": "Object",
+                "name": "Foo",
+                "properties": [
+                  {
+                    "kind": "String",
+                    "name": "bar",
+                    "type": ""baz"",
+                  },
+                ],
+                "type": "Foo",
+              },
+            ],
+            "kind": "Generic",
+            "name": "value",
+            "type": "Promise<Foo>",
+          },
+        ],
+        "type": "AsyncString",
+      }
+    `)
+  })
+
+  test('unwraps generic types', () => {
+    const project = new Project()
+
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      dedent`
+      type DistributiveOmit<T, K extends PropertyKey> = T extends any
+        ? Omit<T, K>
+        : never
+
+      type BaseType = {
+        url: string
+        title: string
+      }
+
+      type A = {
+        a: Promise<number>
+      } & BaseType
+
+      type B = {
+        b: number
+      } & BaseType
+
+      type UnionType = A | B
+
+      type UnwrapPromisesInMap<T> = {
+        [K in keyof T]: T[K] extends Promise<infer U> ? U : T[K]
+      }
+
+      type ExportedType = UnwrapPromisesInMap<DistributiveOmit<UnionType, 'title'>>
+      `
+    )
+
+    const typeAlias = sourceFile.getTypeAliasOrThrow('ExportedType')
+    const processedProperties = processType(typeAlias.getType())
+
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "kind": "Union",
+        "name": "ExportedType",
+        "properties": [
+          {
+            "kind": "Object",
+            "name": "UnwrapPromisesInMap",
+            "properties": [
+              {
+                "kind": "Number",
+                "name": "a",
+                "type": "number",
+              },
+              {
+                "kind": "String",
+                "name": "url",
+                "type": "string",
+              },
+            ],
+            "type": "UnwrapPromisesInMap<Omit<A, "title">>",
+          },
+          {
+            "kind": "Object",
+            "name": "UnwrapPromisesInMap",
+            "properties": [
+              {
+                "kind": "String",
+                "name": "url",
+                "type": "string",
+              },
+              {
+                "kind": "Number",
+                "name": "b",
+                "type": "number",
+              },
+            ],
+            "type": "UnwrapPromisesInMap<Omit<B, "title">>",
+          },
+        ],
+        "type": "ExportedType",
       }
     `)
   })

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -403,9 +403,15 @@ export function processCallSignatures(
           )
 
           if (processedType) {
+            let name: string | undefined = parameter.getName()
+
+            if (name.startsWith('_')) {
+              name = undefined
+            }
+
             return {
               ...processedType,
-              name: parameter.getName(),
+              name,
               description: getSymbolDescription(parameter),
             } satisfies ProcessedProperty
           }

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -533,14 +533,11 @@ export function processCallSignatures(
       simplifiedTypeText = `${genericsText}(${parametersText}) => ${returnType}`
     }
 
-    let modifier: ReturnType<typeof getModifier> = undefined
-
-    if (
+    const modifier: ReturnType<typeof getModifier> =
       Node.isFunctionDeclaration(signatureDeclaration) ||
       Node.isMethodDeclaration(signatureDeclaration)
-    ) {
-      modifier = getModifier(signatureDeclaration)
-    }
+        ? getModifier(signatureDeclaration)
+        : undefined
 
     return {
       type: simplifiedTypeText,

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -469,7 +469,7 @@ export function processTypeProperties(
         }
       } else {
         throw new Error(
-          `processTypeProperties: No parameter declaration found for: ${property.getName()}`
+          `[processTypeProperties]: No property declaration found for "${property.getName()}". You must pass the enclosing node as the second argument to "processTypeProperties".`
         )
       }
     })

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -534,7 +534,7 @@ export function processCallSignatures(
       simplifiedTypeText = `${genericsText}(${parametersText}) => ${returnType}`
     }
 
-    let modifier = undefined
+    let modifier: ReturnType<typeof getModifier> = undefined
 
     if (
       Node.isFunctionDeclaration(signatureDeclaration) ||

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -361,19 +361,6 @@ export function processType(
           false
         ),
       } satisfies FunctionProperty
-    } else if (type.isInterface()) {
-      processedProperty = {
-        kind: 'Object',
-        name: symbol ? symbol.getName() : undefined,
-        type: typeText,
-        properties: processTypeProperties(
-          type,
-          declaration,
-          filter,
-          references,
-          false
-        ),
-      } satisfies ObjectProperty
     } else if (isPrimitive) {
       processedProperty = {
         kind: 'Primitive',

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -402,30 +402,6 @@ export function processType(
         kind: 'Primitive',
         type: typeText,
       } satisfies PrimitiveProperty
-    } else if (typeArguments.length > 0) {
-      const processedTypeArguments = typeArguments
-        .map((type) =>
-          processType(
-            type,
-            declaration,
-            filter,
-            references,
-            false,
-            defaultValues
-          )
-        )
-        .filter(Boolean) as ProcessedProperty[]
-
-      if (processedTypeArguments.length === 0) {
-        return
-      }
-
-      processedProperty = {
-        name: symbolMetadata.name,
-        kind: 'Generic',
-        type: typeText,
-        arguments: processedTypeArguments,
-      } satisfies GenericProperty
     } else if (type.isObject()) {
       const properties = processTypeProperties(
         type,
@@ -436,16 +412,40 @@ export function processType(
         defaultValues
       )
 
-      if (properties.length === 0) {
-        return undefined
-      }
+      if (properties.length === 0 && typeArguments.length > 0) {
+        const processedTypeArguments = typeArguments
+          .map((type) =>
+            processType(
+              type,
+              declaration,
+              filter,
+              references,
+              false,
+              defaultValues
+            )
+          )
+          .filter(Boolean) as ProcessedProperty[]
 
-      processedProperty = {
-        name: symbolMetadata.name,
-        kind: 'Object',
-        type: typeText,
-        properties,
-      } satisfies ObjectProperty
+        if (processedTypeArguments.length === 0) {
+          return
+        }
+
+        processedProperty = {
+          name: symbolMetadata.name,
+          kind: 'Generic',
+          type: typeText,
+          arguments: processedTypeArguments,
+        } satisfies GenericProperty
+      } else if (properties.length === 0) {
+        return undefined
+      } else {
+        processedProperty = {
+          name: symbolMetadata.name,
+          kind: 'Object',
+          type: typeText,
+          properties,
+        } satisfies ObjectProperty
+      }
     } else {
       /** Finally, try to process the apparent type if it is different from the current type. */
       const apparentType = type.getApparentType()

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -456,7 +456,9 @@ export function processCallSignatures(
     const simplifiedTypeText = `${genericsText}(${parameters
       .map((parameter) => {
         const questionMark = parameter.isOptional ? '?' : ''
-        return `${parameter.name}${questionMark}: ${parameter.type}`
+        return parameter.name
+          ? `${parameter.name}${questionMark}: ${parameter.type}`
+          : parameter.type
       })
       .join(', ')}) => ${returnType}`
 

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -270,7 +270,13 @@ export function processType(
     processedProperty = {
       kind: 'Tuple',
       type: typeText,
-      elements: processTypeTupleElements(type, declaration, filter, references),
+      elements: processTypeTupleElements(
+        type,
+        declaration,
+        filter,
+        references,
+        false
+      ),
     } satisfies TupleProperty
   } else {
     /** Detect self-references to avoid infinite recursion */
@@ -310,7 +316,13 @@ export function processType(
           name: symbolMetadata.name,
           kind: 'Function',
           type: typeText,
-          signatures: processCallSignatures(callSignatures),
+          signatures: processCallSignatures(
+            callSignatures,
+            declaration,
+            filter,
+            references,
+            false
+          ),
         } satisfies FunctionProperty
       } else if (type.isInterface()) {
         processedProperty = {
@@ -321,7 +333,8 @@ export function processType(
             type,
             declaration,
             filter,
-            references
+            references,
+            false
           ),
         } satisfies InterfaceProperty
       } else if (isPrimitive) {
@@ -334,7 +347,8 @@ export function processType(
           type,
           declaration,
           filter,
-          references
+          references,
+          false
         )
 
         // TODO: use appropriate kind based on declaration (isNode) rather than isObject
@@ -378,7 +392,9 @@ export function processType(
 export function processCallSignatures(
   signatures: Signature[],
   enclosingNode?: Node,
-  filter: SymbolFilter = defaultFilter
+  filter: SymbolFilter = defaultFilter,
+  references: Set<string> = new Set(),
+  isRootType: boolean = true
 ): FunctionSignature[] {
   return signatures.map((signature) => {
     const generics = signature
@@ -399,7 +415,9 @@ export function processCallSignatures(
           const processedType = processType(
             parameterType,
             enclosingNode,
-            filter
+            filter,
+            references,
+            isRootType
           )
 
           if (processedType) {
@@ -439,7 +457,8 @@ export function processTypeProperties(
   type: Type,
   enclosingNode?: Node,
   filter: SymbolFilter = defaultFilter,
-  references: Set<string> = new Set()
+  references: Set<string> = new Set(),
+  isRootType: boolean = true
 ): ProcessedProperty[] {
   // TODO: to determine if a property signature is filtered both the
   return type
@@ -463,7 +482,8 @@ export function processTypeProperties(
           propertyType,
           declaration,
           filter,
-          references
+          references,
+          isRootType
         )
 
         if (processedProperty) {
@@ -487,7 +507,8 @@ function processTypeTupleElements(
   type: Type,
   enclosingNode?: Node,
   filter?: SymbolFilter,
-  references?: Set<string>
+  references: Set<string> = new Set(),
+  isRootType: boolean = true
 ) {
   const tupleNames = type
     .getText()
@@ -504,7 +525,8 @@ function processTypeTupleElements(
         tupleElementType,
         enclosingNode,
         filter,
-        references
+        references,
+        isRootType
       )
       if (processedType) {
         return {

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -532,16 +532,12 @@ export function processTypeProperties(
   filter: SymbolFilter = defaultFilter,
   references: Set<string> = new Set(),
   isRootType: boolean = true,
-  defaultValuesOption?: Record<string, unknown> | unknown
+  defaultValues?: Record<string, unknown> | unknown
 ): ProcessedProperty[] {
   const typeProperties = type.getApparentProperties()
   const propertyDeclarations = typeProperties.map((property) =>
     property.getDeclarations().at(0)
   ) as (PropertySignature | undefined)[]
-  const defaultValues = (defaultValuesOption ||
-    getDefaultValuesFromProperties(
-      propertyDeclarations.filter(Boolean) as PropertySignature[]
-    )) as Record<string, unknown>
 
   return typeProperties
     .map((property, index) => {
@@ -559,9 +555,12 @@ export function processTypeProperties(
 
       if (declaration) {
         const name = property.getName()
-        const defaultValue = propertyDeclaration
-          ? defaultValues[getDefaultValueKey(propertyDeclaration)]
-          : undefined
+        const defaultValue =
+          defaultValues && propertyDeclaration
+            ? (defaultValues as Record<string, unknown>)[
+                getDefaultValueKey(propertyDeclaration)
+              ]
+            : undefined
 
         // Store the metadata of the enclosing node for file location comparison used in processType
         enclosingNodeMetadata.set(declaration, symbolMetadata)

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -2,6 +2,8 @@ import {
   Node,
   Type,
   TypeFormatFlags,
+  type FunctionDeclaration,
+  type MethodDeclaration,
   type ParameterDeclaration,
   type PropertySignature,
   type Signature,
@@ -91,6 +93,7 @@ export interface FunctionProperty extends SharedProperty {
 }
 
 export interface FunctionSignature {
+  modifier?: 'async' | 'generator'
   parameters: ProcessedProperty[]
   type: string
   returnType: string
@@ -531,8 +534,18 @@ export function processCallSignatures(
       simplifiedTypeText = `${genericsText}(${parametersText}) => ${returnType}`
     }
 
+    let modifier = undefined
+
+    if (
+      Node.isFunctionDeclaration(signatureDeclaration) ||
+      Node.isMethodDeclaration(signatureDeclaration)
+    ) {
+      modifier = getModifier(signatureDeclaration)
+    }
+
     return {
       type: simplifiedTypeText,
+      modifier,
       parameters,
       returnType,
     }
@@ -773,6 +786,17 @@ function getSymbolMetadata(
     isExternal,
     isInNodeModules,
     isGlobal: isInNodeModules && !isExported,
+  }
+}
+
+/** Get the modifier of a function or method declaration. */
+function getModifier(node: FunctionDeclaration | MethodDeclaration) {
+  if (node.isAsync()) {
+    return 'async'
+  }
+
+  if (node.isGenerator()) {
+    return 'generator'
   }
 }
 

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -458,8 +458,9 @@ export function processCallSignatures(
   isRootType: boolean = true
 ): FunctionSignature[] {
   return signatures.map((signature) => {
+    const signatureDeclaration = signature.getDeclaration()
     const signatureParameters = signature.getParameters()
-    const signatureDeclarations = signatureParameters.map((parameter) =>
+    const parameterDeclarations = signatureParameters.map((parameter) =>
       parameter.getDeclarations().at(0)
     ) as (ParameterDeclaration | undefined)[]
     const generics = signature
@@ -468,11 +469,11 @@ export function processCallSignatures(
       .join(', ')
     const genericsText = generics ? `<${generics}>` : ''
     const defaultValues = getDefaultValuesFromProperties(
-      signatureDeclarations.filter(Boolean) as ParameterDeclaration[]
+      parameterDeclarations.filter(Boolean) as ParameterDeclaration[]
     )
     const parameters = signatureParameters
       .map((parameter, index) => {
-        const parameterDeclaration = signatureDeclarations[index]
+        const parameterDeclaration = parameterDeclarations[index]
         const isOptional = parameterDeclaration
           ? parameterDeclaration.hasQuestionToken()
           : undefined
@@ -482,9 +483,8 @@ export function processCallSignatures(
           const defaultValue = parameterDeclaration
             ? defaultValues[getDefaultValueKey(parameterDeclaration)]
             : undefined
-          const parameterType = parameter.getTypeAtLocation(declaration)
           const processedType = processType(
-            parameterType,
+            parameter.getTypeAtLocation(signatureDeclaration),
             enclosingNode,
             filter,
             references,
@@ -525,7 +525,6 @@ export function processCallSignatures(
           : parameter.type
       })
       .join(', ')
-    const signatureDeclaration = signature.getDeclaration()
     let simplifiedTypeText: string
 
     if (Node.isFunctionDeclaration(signatureDeclaration)) {

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -424,6 +424,20 @@ export function processType(
           properties,
         } satisfies ObjectProperty
       }
+    } else {
+      /** Finally, try to process the apparent type if it is different from the current type. */
+      const apparentType = type.getApparentType()
+
+      if (type !== apparentType) {
+        return processType(
+          apparentType,
+          declaration,
+          filter,
+          references,
+          false,
+          defaultValues
+        )
+      }
     }
   }
 

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -1,0 +1,339 @@
+import {
+  Node,
+  Type,
+  TypeFormatFlags,
+  type Signature,
+  type Symbol,
+} from 'ts-morph'
+
+import { getJsDocMetadata } from '../js-docs'
+import { getDefaultValuesFromProperties } from '../properties'
+import { getSymbolDescription } from '../symbols'
+
+export interface SharedProperty {
+  name?: string
+  description?: string
+  tags?: { tagName: string; text?: string }[]
+}
+
+export interface ArrayProperty extends SharedProperty {
+  kind: 'Array'
+  type: ProcessedProperty
+}
+
+export interface ObjectProperty extends SharedProperty {
+  kind: 'Object'
+  type: string
+  properties: ProcessedProperty[]
+}
+
+export interface UnionProperty extends SharedProperty {
+  kind: 'Union'
+  type: string
+  properties: ProcessedProperty[]
+}
+
+export interface IntersectionProperty extends SharedProperty {
+  kind: 'Intersection'
+  type: string
+  properties: ProcessedProperty[]
+}
+
+export interface TupleProperty extends SharedProperty {
+  kind: 'Tuple'
+  type: string
+  elements: ProcessedProperty[]
+}
+
+export interface BooleanProperty extends SharedProperty {
+  kind: 'Boolean'
+  type: string
+}
+
+export interface NumberProperty extends SharedProperty {
+  kind: 'Number'
+  type: string
+}
+
+export interface StringProperty extends SharedProperty {
+  kind: 'String'
+  type: string
+}
+
+export interface LiteralProperty extends SharedProperty {
+  kind: 'Literal'
+  type: string
+}
+
+export interface FunctionProperty extends SharedProperty {
+  kind: 'Function'
+  type: string
+  signatures: FunctionSignature[]
+}
+
+export interface FunctionSignature {
+  parameters: ProcessedProperty[]
+  type: string
+  returnType: string
+}
+
+export interface InterfaceProperty extends SharedProperty {
+  kind: 'Interface'
+  type: string
+  properties: ProcessedProperty[]
+}
+
+export interface PromiseProperty extends SharedProperty {
+  kind: 'Promise'
+  type: ProcessedProperty
+}
+
+export interface UnknownProperty extends SharedProperty {
+  kind: 'Unknown'
+  type: string
+}
+
+export interface ReferenceProperty extends SharedProperty {
+  kind: 'Reference'
+  type: string
+}
+
+export type ProcessedProperty =
+  | BooleanProperty
+  | NumberProperty
+  | StringProperty
+  | LiteralProperty
+  | PromiseProperty
+  | ArrayProperty
+  | UnionProperty
+  | IntersectionProperty
+  | TupleProperty
+  | FunctionProperty
+  | InterfaceProperty
+  | ObjectProperty
+  | UnknownProperty
+  | ReferenceProperty
+
+const processedTypesCache = new Map<string, ProcessedProperty>()
+
+/** Process type metadata. */
+export function processType(
+  type: Type,
+  references: Set<string> = new Set()
+): ProcessedProperty {
+  const typeText = type.getText(
+    undefined,
+    TypeFormatFlags.UseAliasDefinedOutsideCurrentScope
+  )
+
+  // Check if the type has already been processed
+  if (processedTypesCache.has(typeText)) {
+    return processedTypesCache.get(typeText)!
+  }
+
+  // Detect recursion and return a reference
+  if (references.has(typeText)) {
+    return {
+      kind: 'Reference',
+      type: typeText,
+    } satisfies ReferenceProperty
+  }
+
+  references.add(typeText)
+
+  const symbol = type.getAliasSymbol() || type.getSymbol()
+  let name = symbol ? symbol.getName() : undefined
+
+  if (
+    name === '__type' ||
+    name === '__call' ||
+    name === '__new' ||
+    name === '__object'
+  ) {
+    name = undefined
+  }
+
+  let processedProperty: ProcessedProperty
+
+  if (type.isBoolean()) {
+    processedProperty = {
+      kind: 'Boolean',
+      type: typeText,
+    } satisfies BooleanProperty
+  } else if (type.isNumber()) {
+    processedProperty = {
+      kind: 'Number',
+      type: typeText,
+    } satisfies NumberProperty
+  } else if (type.isString()) {
+    processedProperty = {
+      kind: 'String',
+      type: typeText,
+    } satisfies StringProperty
+  } else if (type.isLiteral()) {
+    processedProperty = {
+      kind: 'Literal',
+      type: typeText,
+    } satisfies LiteralProperty
+  } else if (isPromise(type)) {
+    const [promiseType] = type.getTypeArguments()
+    processedProperty = {
+      kind: 'Promise',
+      type: processType(promiseType, references),
+    } satisfies PromiseProperty
+  } else if (type.isArray()) {
+    const elementType = type.getArrayElementTypeOrThrow()
+    processedProperty = {
+      kind: 'Array',
+      type: processType(elementType, references),
+    } satisfies ArrayProperty
+  } else if (type.isUnion()) {
+    processedProperty = {
+      name,
+      kind: 'Union',
+      type: typeText,
+      properties: type
+        .getUnionTypes()
+        .map((unionType) => processType(unionType, references)),
+    } satisfies UnionProperty
+  } else if (type.isIntersection()) {
+    processedProperty = {
+      name,
+      kind: 'Intersection',
+      type: typeText,
+      properties: type
+        .getIntersectionTypes()
+        .map((intersectionType) => processType(intersectionType, references)),
+    } satisfies IntersectionProperty
+  } else if (type.isTuple()) {
+    const tupleNames = type
+      .getText()
+      .slice(1, -1)
+      .split(',')
+      .map((signature) => {
+        const [name] = signature.split(':')
+        return name ? name.trim() : undefined
+      })
+    processedProperty = {
+      kind: 'Tuple',
+      type: typeText,
+      elements: type.getTupleElements().map((tupleElementType, index) => ({
+        ...processType(tupleElementType, references),
+        name: tupleNames[index],
+      })) satisfies ProcessedProperty[],
+    } satisfies TupleProperty
+  } else {
+    const callSignatures = type.getCallSignatures()
+    if (callSignatures.length > 0) {
+      processedProperty = {
+        name,
+        kind: 'Function',
+        type: typeText,
+        signatures: processCallSignatures(callSignatures),
+      } satisfies FunctionProperty
+    } else if (type.isInterface()) {
+      const symbol = type.getAliasSymbol()
+      processedProperty = {
+        kind: 'Interface',
+        name: symbol ? symbol.getName() : undefined,
+        type: typeText,
+        properties: processTypeProperties(
+          type,
+          // @ts-expect-error - private argument
+          references
+        ),
+      } satisfies InterfaceProperty
+    } else if (type.isObject()) {
+      processedProperty = {
+        name,
+        kind: 'Object',
+        type: typeText,
+        properties: processTypeProperties(
+          type,
+          // @ts-expect-error - private argument
+          references
+        ),
+      } satisfies ObjectProperty
+    } else {
+      processedProperty = {
+        kind: 'Unknown',
+        type: typeText,
+      } satisfies UnknownProperty
+    }
+  }
+
+  references.delete(typeText)
+  processedTypesCache.set(typeText, processedProperty)
+
+  return processedProperty
+}
+
+/** Process all function signatures of a given type including their parameters and return types. */
+export function processCallSignatures(
+  signatures: Signature[]
+): FunctionSignature[] {
+  return signatures.map((signature) => {
+    const generics = signature
+      .getTypeParameters()
+      .map((parameter) => parameter.getText())
+      .join(', ')
+    const genericsText = generics ? `<${generics}>` : ''
+    const parameters = signature.getParameters().map((parameter) => {
+      const parameterDeclaration = getSymbolDeclarationOrThrow(parameter)
+      const parameterType = parameter.getTypeAtLocation(parameterDeclaration)
+      return {
+        ...processType(parameterType),
+        name: parameter.getName(),
+        description: getSymbolDescription(parameter),
+      } satisfies ProcessedProperty
+    })
+    const returnType = signature
+      .getReturnType()
+      .getText(undefined, TypeFormatFlags.UseAliasDefinedOutsideCurrentScope)
+    const simplifiedTypeText = `${genericsText}(${parameters
+      .map((parameter) => `${parameter.name}: ${parameter.type}`)
+      .join(', ')}) => ${returnType}`
+    return {
+      type: simplifiedTypeText,
+      parameters,
+      returnType,
+    }
+  })
+}
+
+/** Process all properties of a given type */
+export function processTypeProperties(type: Type): ProcessedProperty[] {
+  const references: Set<string> = arguments[1] || new Set()
+  return type.getProperties().map((property) => {
+    const propertyDeclaration = getSymbolDeclarationOrThrow(property)
+    const propertyType = property.getTypeAtLocation(propertyDeclaration)
+    return {
+      ...processType(propertyType, references),
+      ...getJsDocMetadata(propertyDeclaration),
+      name: property.getName(),
+    } satisfies ProcessedProperty
+  })
+}
+
+/** Attempt to get the declaration of a symbol or throw an error. */
+function getSymbolDeclarationOrThrow<DeclarationType extends Node = Node>(
+  symbol: Symbol
+) {
+  const [declaration] = symbol.getDeclarations()
+  if (!declaration) {
+    throw new Error(
+      `Could not find declaration for symbol: ${symbol.getName()}`
+    )
+  }
+  return declaration as DeclarationType
+}
+
+/** Check if a type is a promise. */
+function isPromise(type: Type) {
+  const symbol = type.getSymbol()
+  if (!symbol) {
+    return false
+  }
+  const typeArguments = type.getTypeArguments()
+  return symbol.getName() === 'Promise' && typeArguments.length === 1
+}

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -2,6 +2,7 @@ import {
   Node,
   Type,
   TypeFormatFlags,
+  ts,
   type Signature,
   type Symbol,
 } from 'ts-morph'
@@ -27,11 +28,20 @@ export interface ObjectProperty extends SharedProperty {
   properties: ProcessedProperty[]
 }
 
+export interface GenericProperty extends SharedProperty {
+  kind: 'Generic'
+  type: string
+  arguments: ProcessedProperty[]
+}
+
 export interface UnionProperty extends SharedProperty {
   kind: 'Union'
   type: string
   properties: ProcessedProperty[]
 }
+
+// TODO: add UnionLiteral to handle union literals like 'foo' | 'bar' that can just print the type instead of each property
+// this should also be the case for a UnionPrimitive type like string | number | boolean
 
 export interface IntersectionProperty extends SharedProperty {
   kind: 'Intersection'
@@ -60,8 +70,8 @@ export interface StringProperty extends SharedProperty {
   type: string
 }
 
-export interface LiteralProperty extends SharedProperty {
-  kind: 'Literal'
+export interface SymbolProperty extends SharedProperty {
+  kind: 'Symbol'
   type: string
 }
 
@@ -83,11 +93,6 @@ export interface InterfaceProperty extends SharedProperty {
   properties: ProcessedProperty[]
 }
 
-export interface PromiseProperty extends SharedProperty {
-  kind: 'Promise'
-  type: ProcessedProperty
-}
-
 export interface UnknownProperty extends SharedProperty {
   kind: 'Unknown'
   type: string
@@ -96,14 +101,17 @@ export interface UnknownProperty extends SharedProperty {
 export interface ReferenceProperty extends SharedProperty {
   kind: 'Reference'
   type: string
+  // path?: string // TODO: add import specifier for external references and identifier for internal references
+  isExternal?: boolean
+  isInNodeModules?: boolean
 }
 
 export type ProcessedProperty =
   | BooleanProperty
   | NumberProperty
   | StringProperty
-  | LiteralProperty
-  | PromiseProperty
+  | SymbolProperty
+  | GenericProperty
   | ArrayProperty
   | UnionProperty
   | IntersectionProperty
@@ -114,163 +122,253 @@ export type ProcessedProperty =
   | UnknownProperty
   | ReferenceProperty
 
-const processedTypesCache = new Map<string, ProcessedProperty>()
+export type SymbolMetadata = ReturnType<typeof getSymbolMetadata>
+
+export type SymbolFilter = (symbolMetadata: SymbolMetadata) => boolean
+
+const enclosingNodeMetadata = new WeakMap<Node, SymbolMetadata>()
+const defaultFilter = (metadata: SymbolMetadata) => !metadata.isInNodeModules
+const TYPE_FORMAT_FLAGS =
+  TypeFormatFlags.NoTruncation |
+  TypeFormatFlags.UseAliasDefinedOutsideCurrentScope
 
 /** Process type metadata. */
 export function processType(
   type: Type,
-  references: Set<string> = new Set()
-): ProcessedProperty {
-  const typeText = type.getText(
-    undefined,
-    TypeFormatFlags.UseAliasDefinedOutsideCurrentScope
-  )
+  enclosingNode?: Node,
+  filter: SymbolFilter = defaultFilter,
+  references: Set<string> = new Set(),
+  isRootType: boolean = true
+): ProcessedProperty | undefined {
+  const typeText = type.getText(enclosingNode, TYPE_FORMAT_FLAGS)
+  const symbol = getTypeSymbol(type)
+  const symbolMetadata = getSymbolMetadata(symbol, enclosingNode)
+  const symbolDeclaration = symbol?.getDeclarations().at(0)
+  const declaration = symbolDeclaration || enclosingNode
+  // const filterResult = filter(symbolMetadata)
 
-  // Check if the type has already been processed
-  if (processedTypesCache.has(typeText)) {
-    return processedTypesCache.get(typeText)!
-  }
+  //  if (filterResult === false) {
+  //   return
+  // }
 
-  // Detect recursion and return a reference
-  if (references.has(typeText)) {
-    return {
-      kind: 'Reference',
-      type: typeText,
-    } satisfies ReferenceProperty
-  }
+  let processedProperty: ProcessedProperty = {
+    kind: 'Unknown',
+    type: typeText,
+  } satisfies UnknownProperty
 
-  references.add(typeText)
-
-  const symbol = type.getAliasSymbol() || type.getSymbol()
-  let name = symbol ? symbol.getName() : undefined
-
-  if (
-    name === '__type' ||
-    name === '__call' ||
-    name === '__new' ||
-    name === '__object'
-  ) {
-    name = undefined
-  }
-
-  let processedProperty: ProcessedProperty
-
-  if (type.isBoolean()) {
-    processedProperty = {
-      kind: 'Boolean',
-      type: typeText,
-    } satisfies BooleanProperty
-  } else if (type.isNumber()) {
-    processedProperty = {
-      kind: 'Number',
-      type: typeText,
-    } satisfies NumberProperty
-  } else if (type.isString()) {
-    processedProperty = {
-      kind: 'String',
-      type: typeText,
-    } satisfies StringProperty
-  } else if (type.isLiteral()) {
-    processedProperty = {
-      kind: 'Literal',
-      type: typeText,
-    } satisfies LiteralProperty
-  } else if (isPromise(type)) {
-    const [promiseType] = type.getTypeArguments()
-    processedProperty = {
-      kind: 'Promise',
-      type: processType(promiseType, references),
-    } satisfies PromiseProperty
-  } else if (type.isArray()) {
+  // if (symbolMetadata.isExternal && !symbolMetadata.isInNodeModules) {
+  //   processedProperty = {
+  //     kind: 'Reference',
+  //     name: symbolMetadata.name,
+  //     type: typeText,
+  //     isExternal: true,
+  //     isInNodeModules: false,
+  //   } satisfies ReferenceProperty
+  // } else
+  if (type.isArray()) {
     const elementType = type.getArrayElementTypeOrThrow()
-    processedProperty = {
-      kind: 'Array',
-      type: processType(elementType, references),
-    } satisfies ArrayProperty
-  } else if (type.isUnion()) {
-    processedProperty = {
-      name,
-      kind: 'Union',
-      type: typeText,
-      properties: type
-        .getUnionTypes()
-        .map((unionType) => processType(unionType, references)),
-    } satisfies UnionProperty
-  } else if (type.isIntersection()) {
-    processedProperty = {
-      name,
-      kind: 'Intersection',
-      type: typeText,
-      properties: type
-        .getIntersectionTypes()
-        .map((intersectionType) => processType(intersectionType, references)),
-    } satisfies IntersectionProperty
-  } else if (type.isTuple()) {
-    const tupleNames = type
-      .getText()
-      .slice(1, -1)
-      .split(',')
-      .map((signature) => {
-        const [name] = signature.split(':')
-        return name ? name.trim() : undefined
-      })
-    processedProperty = {
-      kind: 'Tuple',
-      type: typeText,
-      elements: type.getTupleElements().map((tupleElementType, index) => ({
-        ...processType(tupleElementType, references),
-        name: tupleNames[index],
-      })) satisfies ProcessedProperty[],
-    } satisfies TupleProperty
-  } else {
-    const callSignatures = type.getCallSignatures()
-    if (callSignatures.length > 0) {
+    const processedElementType = processType(
+      elementType,
+      declaration,
+      filter,
+      references,
+      false
+    )
+    if (processedElementType) {
       processedProperty = {
-        name,
-        kind: 'Function',
-        type: typeText,
-        signatures: processCallSignatures(callSignatures),
-      } satisfies FunctionProperty
-    } else if (type.isInterface()) {
-      const symbol = type.getAliasSymbol()
-      processedProperty = {
-        kind: 'Interface',
-        name: symbol ? symbol.getName() : undefined,
-        type: typeText,
-        properties: processTypeProperties(
-          type,
-          // @ts-expect-error - private argument
-          references
-        ),
-      } satisfies InterfaceProperty
-    } else if (type.isObject()) {
-      processedProperty = {
-        name,
-        kind: 'Object',
-        type: typeText,
-        properties: processTypeProperties(
-          type,
-          // @ts-expect-error - private argument
-          references
-        ),
-      } satisfies ObjectProperty
+        kind: 'Array',
+        type: processedElementType,
+      } satisfies ArrayProperty
     } else {
-      processedProperty = {
-        kind: 'Unknown',
+      return
+    }
+  } else {
+    /**
+     * Compare the declaration location with the type symbol declaration location
+     * to determine if the property type is a reference to a type in node modules.
+     */
+    // if (enclosingNode && !isPrimitiveType(type)) {
+    //   const enclosingSymbolMetadata = enclosingNodeMetadata.get(enclosingNode)!
+    //   const inSeparateProjects =
+    //     enclosingSymbolMetadata?.isInNodeModules === false &&
+    //     symbolMetadata.isInNodeModules
+
+    //   if (inSeparateProjects) {
+    //     return {
+    //       kind: 'Reference',
+    //       type: typeText,
+    //     } satisfies ReferenceProperty
+    //   }
+    // }
+
+    /** Local exported symbol types are also processed so they are treated as a reference. */
+    if (
+      !isRootType &&
+      !symbolMetadata.isExternal &&
+      symbolMetadata.isExported
+    ) {
+      return {
+        kind: 'Reference',
         type: typeText,
-      } satisfies UnknownProperty
+      } satisfies ReferenceProperty
+    }
+
+    /** Detect self-references to avoid infinite recursion */
+    if (references.has(typeText)) {
+      return {
+        kind: 'Reference',
+        type: typeText,
+      } satisfies ReferenceProperty
+    }
+
+    references.add(typeText)
+
+    if (type.isBoolean() || type.isBooleanLiteral()) {
+      processedProperty = {
+        kind: 'Boolean',
+        type: typeText,
+      } satisfies BooleanProperty
+    } else if (type.isNumber() || type.isNumberLiteral()) {
+      processedProperty = {
+        kind: 'Number',
+        type: typeText,
+      } satisfies NumberProperty
+    } else if (type.isString() || type.isStringLiteral()) {
+      processedProperty = {
+        kind: 'String',
+        type: typeText,
+      } satisfies StringProperty
+    } else if (isSymbol(type)) {
+      return {
+        kind: 'Symbol',
+        type: typeText,
+      } satisfies SymbolProperty
+    } else if (type.isUnion()) {
+      processedProperty = {
+        name: symbolMetadata.name,
+        kind: 'Union',
+        type: typeText,
+        properties: type
+          .getUnionTypes()
+          .map((unionType) =>
+            processType(unionType, declaration, filter, references, false)
+          )
+          .filter(Boolean) as ProcessedProperty[],
+      } satisfies UnionProperty
+    } else if (type.isIntersection()) {
+      processedProperty = {
+        name: symbolMetadata.name,
+        kind: 'Intersection',
+        type: typeText,
+        properties: type
+          .getIntersectionTypes()
+          .map((intersectionType) =>
+            processType(
+              intersectionType,
+              declaration,
+              filter,
+              references,
+              false
+            )
+          )
+          .filter(Boolean) as ProcessedProperty[],
+      } satisfies IntersectionProperty
+      // } else if (
+      //   // Skip external types in node_modules unless they are explicitly included
+      //   // in which case we treat them as normal and continue processing
+      //   filterResult ? false : symbolMetadata.isInNodeModules
+      // ) {
+      //   processedProperty = {
+      //     kind: 'Reference',
+      //     name: symbolMetadata.name,
+      //     type: typeText,
+      //     isExternal: true,
+      //     isInNodeModules: true,
+      //   } satisfies ReferenceProperty
+    } else if (type.isTuple()) {
+      processedProperty = {
+        kind: 'Tuple',
+        type: typeText,
+        elements: processTypeTupleElements(
+          type,
+          declaration,
+          filter,
+          references
+        ),
+      } satisfies TupleProperty
+    } else {
+      const callSignatures = type.getCallSignatures()
+      if (callSignatures.length > 0) {
+        processedProperty = {
+          name: symbolMetadata.name,
+          kind: 'Function',
+          type: typeText,
+          signatures: processCallSignatures(callSignatures),
+        } satisfies FunctionProperty
+      } else if (type.isInterface()) {
+        processedProperty = {
+          kind: 'Interface',
+          name: symbol ? symbol.getName() : undefined,
+          type: typeText,
+          properties: processTypeProperties(
+            type,
+            declaration,
+            filter,
+            references
+          ),
+        } satisfies InterfaceProperty
+      } else if (isPrimitiveType(type)) {
+        processedProperty = {
+          kind: 'Unknown',
+          type: typeText,
+        } satisfies UnknownProperty
+      } else if (type.isObject()) {
+        const properties = processTypeProperties(
+          type,
+          declaration,
+          filter,
+          references
+        )
+        const typeArguments = type.getTypeArguments()
+
+        // If the type has no properties but has type arguments, we assume it is a generic type and process the type arguments
+        if (properties.length === 0 && typeArguments.length > 0) {
+          const processedTypeArguments = typeArguments
+            .map((type) =>
+              processType(type, declaration, filter, references, false)
+            )
+            .filter(Boolean) as ProcessedProperty[]
+
+          if (processedTypeArguments.length > 0) {
+            processedProperty = {
+              name: symbolMetadata.name,
+              kind: 'Generic',
+              type: typeText,
+              arguments: processedTypeArguments,
+            } satisfies GenericProperty
+          }
+        } else {
+          processedProperty = {
+            name: symbolMetadata.name,
+            kind: 'Object',
+            type: typeText,
+            properties,
+          } satisfies ObjectProperty
+        }
+      }
     }
   }
 
   references.delete(typeText)
-  processedTypesCache.set(typeText, processedProperty)
 
   return processedProperty
 }
 
 /** Process all function signatures of a given type including their parameters and return types. */
 export function processCallSignatures(
-  signatures: Signature[]
+  signatures: Signature[],
+  enclosingNode?: Node,
+  filter: SymbolFilter = defaultFilter
 ): FunctionSignature[] {
   return signatures.map((signature) => {
     const generics = signature
@@ -278,21 +376,38 @@ export function processCallSignatures(
       .map((parameter) => parameter.getText())
       .join(', ')
     const genericsText = generics ? `<${generics}>` : ''
-    const parameters = signature.getParameters().map((parameter) => {
-      const parameterDeclaration = getSymbolDeclarationOrThrow(parameter)
-      const parameterType = parameter.getTypeAtLocation(parameterDeclaration)
-      return {
-        ...processType(parameterType),
-        name: parameter.getName(),
-        description: getSymbolDescription(parameter),
-      } satisfies ProcessedProperty
-    })
+    const parameters = signature
+      .getParameters()
+      .map((parameter) => {
+        const parameterDeclaration = parameter.getDeclarations().at(0)
+        const declaration = parameterDeclaration || enclosingNode
+
+        if (declaration) {
+          const parameterType = parameter.getTypeAtLocation(declaration)
+          const processedType = processType(
+            parameterType,
+            enclosingNode,
+            filter
+          )
+
+          if (processedType) {
+            return {
+              ...processedType,
+              name: parameter.getName(),
+              description: getSymbolDescription(parameter),
+            } satisfies ProcessedProperty
+          }
+        }
+      })
+      .filter(Boolean) as ProcessedProperty[]
     const returnType = signature
       .getReturnType()
       .getText(undefined, TypeFormatFlags.UseAliasDefinedOutsideCurrentScope)
+    // TODO: account for method, function declaration, etc.
     const simplifiedTypeText = `${genericsText}(${parameters
       .map((parameter) => `${parameter.name}: ${parameter.type}`)
       .join(', ')}) => ${returnType}`
+
     return {
       type: simplifiedTypeText,
       parameters,
@@ -302,38 +417,205 @@ export function processCallSignatures(
 }
 
 /** Process all properties of a given type */
-export function processTypeProperties(type: Type): ProcessedProperty[] {
-  const references: Set<string> = arguments[1] || new Set()
-  return type.getProperties().map((property) => {
-    const propertyDeclaration = getSymbolDeclarationOrThrow(property)
-    const propertyType = property.getTypeAtLocation(propertyDeclaration)
-    return {
-      ...processType(propertyType, references),
-      ...getJsDocMetadata(propertyDeclaration),
-      name: property.getName(),
-    } satisfies ProcessedProperty
-  })
+export function processTypeProperties(
+  type: Type,
+  enclosingNode?: Node,
+  filter: SymbolFilter = defaultFilter,
+  references: Set<string> = new Set()
+): ProcessedProperty[] {
+  // TODO: to determine if a property signature is filtered both the
+  return type
+    .getProperties()
+    .map((property) => {
+      const symbolMetadata = getSymbolMetadata(property, enclosingNode)
+      const propertyDeclaration = property.getDeclarations().at(0)
+      const declaration = propertyDeclaration || enclosingNode
+      const filterResult = filter(symbolMetadata)
+
+      if (filterResult === false) {
+        return
+      }
+
+      if (declaration) {
+        // Store the metadata of the enclosing node for file location comparison used in processType
+        enclosingNodeMetadata.set(declaration, symbolMetadata)
+
+        const propertyType = property.getTypeAtLocation(declaration)
+        const processedProperty = processType(
+          propertyType,
+          declaration,
+          filter,
+          references
+        )
+
+        if (processedProperty) {
+          return {
+            ...processedProperty,
+            ...getJsDocMetadata(declaration),
+            name: property.getName(),
+          } satisfies ProcessedProperty
+        }
+      } else {
+        throw new Error(
+          `processTypeProperties: No parameter declaration found for: ${property.getName()}`
+        )
+      }
+    })
+    .filter(Boolean) as ProcessedProperty[]
 }
 
-/** Attempt to get the declaration of a symbol or throw an error. */
-function getSymbolDeclarationOrThrow<DeclarationType extends Node = Node>(
-  symbol: Symbol
+/** Process all elements of a tuple type. */
+function processTypeTupleElements(
+  type: Type,
+  enclosingNode?: Node,
+  filter?: SymbolFilter,
+  references?: Set<string>
 ) {
-  const [declaration] = symbol.getDeclarations()
-  if (!declaration) {
-    throw new Error(
-      `Could not find declaration for symbol: ${symbol.getName()}`
-    )
-  }
-  return declaration as DeclarationType
+  const tupleNames = type
+    .getText()
+    .slice(1, -1)
+    .split(',')
+    .map((signature) => {
+      const [name] = signature.split(':')
+      return name ? name.trim() : undefined
+    })
+  return type
+    .getTupleElements()
+    .map((tupleElementType, index) => {
+      const processedType = processType(
+        tupleElementType,
+        enclosingNode,
+        filter,
+        references
+      )
+      if (processedType) {
+        return {
+          ...processedType,
+          name: tupleNames[index],
+        } satisfies ProcessedProperty
+      }
+    })
+    .filter(Boolean) as ProcessedProperty[]
 }
 
-/** Check if a type is a promise. */
-function isPromise(type: Type) {
+/** Checks if a type is a primitive type. */
+function isPrimitiveType(type: Type) {
+  return (
+    type.isBoolean() ||
+    type.isBooleanLiteral() ||
+    type.isNumber() ||
+    type.isNumberLiteral() ||
+    type.isString() ||
+    type.isStringLiteral() ||
+    type.isTemplateLiteral() ||
+    type.isUndefined() ||
+    type.isNull() ||
+    type.isAny() ||
+    type.isUnknown() ||
+    type.isNever() ||
+    isSymbol(type) ||
+    isBigInt(type)
+  )
+}
+
+/** Check if a type is a symbol. */
+function isSymbol(type: Type) {
   const symbol = type.getSymbol()
+  return symbol?.getName() === 'Symbol'
+}
+
+/** Check if a type is a bigint. */
+function isBigInt(type: Type) {
+  return type.getText() === 'bigint'
+}
+
+/** Attempt to get the symbol of a type. */
+function getTypeSymbol(type: Type): Symbol | undefined {
+  const symbol = type.getAliasSymbol() || type.getSymbol()
   if (!symbol) {
-    return false
+    const apparentType = type.getApparentType()
+    return apparentType.getAliasSymbol() || apparentType.getSymbol()
   }
-  const typeArguments = type.getTypeArguments()
-  return symbol.getName() === 'Promise' && typeArguments.length === 1
+  return symbol
+}
+
+/** Gather metadata about a symbol. */
+function getSymbolMetadata(
+  symbol?: Symbol,
+  enclosingNode?: Node
+): {
+  /** The name of the symbol. */
+  name?: string
+
+  /** Whether the symbol is exported. */
+  isExported: boolean
+
+  /** Whether the symbol is external to the current source file. */
+  isExternal: boolean
+
+  /** Whether the symbol is virtual and does not have a declaration. */
+  isVirtual: boolean
+
+  /** Whether the symbol is located in node_modules. */
+  isInNodeModules: boolean
+} {
+  if (!symbol) {
+    return {
+      isExported: false,
+      isExternal: false,
+      isInNodeModules: true,
+      isVirtual: true,
+    }
+  }
+
+  const declarations = symbol.getDeclarations()
+
+  if (declarations.length === 0) {
+    return {
+      isExported: false,
+      isExternal: false,
+      isInNodeModules: false,
+      isVirtual: true,
+    }
+  }
+
+  const declaration = symbol.getDeclarations().at(0)!
+  const declarationSourceFile = declaration?.getSourceFile()
+  const enclosingSourceFile = enclosingNode?.getSourceFile()
+
+  /** Attempt to get the name of the symbol. */
+  let name: string | undefined = symbol.getName()
+
+  if ('getName' in declaration) {
+    // @ts-expect-error - getName is not defined on all declaration types
+    name = declaration.getName()
+  }
+
+  // Ignore private symbol names like __type, __call, __0, etc.
+  if (name?.startsWith('__')) {
+    name = undefined
+  }
+
+  /** Check if the symbol is exported if it is not the enclosing node. */
+  let isExported = false
+
+  if (enclosingNode !== declaration && 'isExported' in declaration) {
+    // @ts-expect-error - isExported is not defined on all declaration types
+    isExported = declaration.isExported()
+  }
+
+  /** Check if a type is external to the enclosing source file. */
+  let isExternal = false
+
+  if (enclosingSourceFile) {
+    isExternal = enclosingSourceFile !== declarationSourceFile
+  }
+
+  return {
+    name,
+    isVirtual: false,
+    isExported,
+    isExternal,
+    isInNodeModules: declarationSourceFile.isInNodeModules(),
+  }
 }

--- a/packages/utils/src/types/processType.ts
+++ b/packages/utils/src/types/processType.ts
@@ -45,12 +45,6 @@ export interface UnionProperty extends SharedProperty {
 // TODO: add UnionLiteral to handle union literals like 'foo' | 'bar' that can just print the type instead of each property
 // this should also be the case for a UnionPrimitive type like string | number | boolean
 
-export interface IntersectionProperty extends SharedProperty {
-  kind: 'Intersection'
-  type: string
-  properties: ProcessedProperty[]
-}
-
 export interface TupleProperty extends SharedProperty {
   kind: 'Tuple'
   type: string
@@ -89,12 +83,6 @@ export interface FunctionSignature {
   returnType: string
 }
 
-export interface InterfaceProperty extends SharedProperty {
-  kind: 'Interface'
-  type: string
-  properties: ProcessedProperty[]
-}
-
 export interface PrimitiveProperty extends SharedProperty {
   kind: 'Primitive'
   type: string
@@ -125,10 +113,8 @@ export type ProcessedProperty =
   | GenericProperty
   | ArrayProperty
   | UnionProperty
-  | IntersectionProperty
   | TupleProperty
   | FunctionProperty
-  | InterfaceProperty
   | ObjectProperty
   | UnknownProperty
   | ReferenceProperty
@@ -310,7 +296,7 @@ export function processType(
   } else if (type.isIntersection()) {
     processedProperty = {
       name: symbolMetadata.name,
-      kind: 'Intersection',
+      kind: 'Object',
       type: typeText,
       properties: type
         .getIntersectionTypes()
@@ -318,7 +304,7 @@ export function processType(
           processType(intersectionType, declaration, filter, references, false)
         )
         .filter(Boolean) as ProcessedProperty[],
-    } satisfies IntersectionProperty
+    } satisfies ObjectProperty
   } else if (type.isTuple()) {
     processedProperty = {
       kind: 'Tuple',
@@ -348,7 +334,7 @@ export function processType(
       } satisfies FunctionProperty
     } else if (type.isInterface()) {
       processedProperty = {
-        kind: 'Interface',
+        kind: 'Object',
         name: symbol ? symbol.getName() : undefined,
         type: typeText,
         properties: processTypeProperties(
@@ -358,7 +344,7 @@ export function processType(
           references,
           false
         ),
-      } satisfies InterfaceProperty
+      } satisfies ObjectProperty
     } else if (isPrimitive) {
       processedProperty = {
         kind: 'Primitive',


### PR DESCRIPTION
Introduces a new `processType` utility designed to improve the robustness of parsing types in complex scenarios. This includes:

- **Recursive Type Unpacking:** Recursively unpacks types based on their kind, ensuring better parsing for types like generics (e.g. Promise).
- **Prevention of Duplicate Documentation:** Prevents the generation of duplicated documentation using references based on whether or not the type is exported, ensuring clarity and conciseness.
- **Handling Self-Referenced Types:** Includes logic to detect and manage self-referenced types, creating references where necessary to prevent infinite recursion.
